### PR TITLE
feat: hold pending connections open for 30s grace period

### DIFF
--- a/internal/greyproxy/plugins/bypass.go
+++ b/internal/greyproxy/plugins/bypass.go
@@ -149,8 +149,9 @@ func (b *Bypass) waitForApproval(ctx context.Context, containerName, host string
 				}
 			case greyproxy.EventPendingDismissed:
 				// The user denied or dismissed the pending request.
-				// If no matching rule exists for us anymore, stop waiting immediately.
-				if greyproxy.FindMatchingRule(b.db, containerName, host, port, resolvedHostname) == nil {
+				// Stop waiting if there's no rule or if the matching rule is a deny.
+				rule := greyproxy.FindMatchingRule(b.db, containerName, host, port, resolvedHostname)
+				if rule == nil || rule.Action == "deny" {
 					b.log.Debugf("DENIED %s -> %s:%d during grace period", containerName, host, port)
 					return nil
 				}


### PR DESCRIPTION
## Summary

- When a connection has no matching rule, instead of refusing immediately, create a pending request **and** hold the connection open for up to 30 seconds
- If the user approves the pending request via the dashboard during that window, the connection is released and goes through
- If the user denies/dismisses the pending request, the connection is closed immediately (previously it would wait the full 30s timeout)
- Uses the existing EventBus pub/sub mechanism: all waiting connections for the same pending request are released simultaneously on approval or denial

## Context

Most HTTP clients (curl, wget, requests, Go net/http, axios, etc.) have connection/read timeouts well above 30 seconds or no timeout at all, making this grace period safe for the vast majority of use cases.

## Test plan

- [x] Verify connection with no matching rule creates a pending request and holds for ~30s
- [x] Approve pending request via dashboard within 30s -- connection should go through
- [x] Deny/dismiss pending request via dashboard -- connection should close immediately
- [x] Multiple connections to the same destination all release on a single approval
- [x] Connections with an explicit deny rule are still refused immediately (no hold)
- [x] Connections with an allow rule are still allowed immediately (no hold)