### PR TITLE
feat: kill active connections when allow rule is deleted

### DIFF
--- a/cmd/greyproxy/program.go
+++ b/cmd/greyproxy/program.go
@@ -262,6 +262,7 @@ func (p *program) buildGreyproxyService() error {
 	shared.Cache = tmpSvc.Cache
 	shared.Bus = tmpSvc.Bus
 	shared.Waiters = tmpSvc.Waiters
+	shared.ConnTracker = greyproxy.NewConnTracker()
 	shared.Version = version
 
 	// Collect listening ports for the health endpoint
@@ -288,7 +289,7 @@ func (p *program) buildGreyproxyService() error {
 	// Create and register gost plugins
 	autherPlugin := greyproxy_plugins.NewAuther()
 	admissionPlugin := greyproxy_plugins.NewAdmission()
-	bypassPlugin := greyproxy_plugins.NewBypass(shared.DB, shared.Cache, shared.Bus, shared.Waiters)
+	bypassPlugin := greyproxy_plugins.NewBypass(shared.DB, shared.Cache, shared.Bus, shared.Waiters, shared.ConnTracker)
 	resolverPlugin := greyproxy_plugins.NewResolver(shared.Cache)
 
 	registry.AutherRegistry().Register(gaCfg.Auther, autherPlugin)
@@ -302,7 +303,7 @@ func (p *program) buildGreyproxyService() error {
 	// Build HTTP router with REST API + HTMX UI + WebSocket
 	router, g := greyproxy_api.NewRouter(shared, gaCfg.PathPrefix)
 	greyproxy_ui.RegisterPageRoutes(g, shared.DB, shared.Bus)
-	greyproxy_ui.RegisterHTMXRoutes(g, shared.DB, shared.Bus, shared.Waiters)
+	greyproxy_ui.RegisterHTMXRoutes(g, shared.DB, shared.Bus, shared.Waiters, shared.ConnTracker)
 
 	// Create the actual service
 	svc := &greyproxy.Service{}

--- a/internal/gostx/ctx/value.go
+++ b/internal/gostx/ctx/value.go
@@ -90,3 +90,30 @@ func ClientIDFromContext(ctx context.Context) ClientID {
 	v, _ := ctx.Value(clientIDKey{}).(ClientID)
 	return v
 }
+
+// ConnCanceller allows registering connection cancel functions by rule ID.
+// Implemented by greyproxy.ConnTracker.
+type ConnCanceller interface {
+	Register(ruleID int64, cancel context.CancelFunc) uint64
+	Unregister(ruleID int64, id uint64)
+}
+
+// BypassResult is a mutable container placed in the context before calling
+// bypass.Contains. The bypass plugin fills in the RuleID and Tracker when
+// a connection is allowed by a rule, so the handler can register the
+// connection for cancellation if the rule is later deleted.
+type BypassResult struct {
+	RuleID  int64
+	Tracker ConnCanceller
+}
+
+type bypassResultKey struct{}
+
+func ContextWithBypassResult(ctx context.Context, result *BypassResult) context.Context {
+	return context.WithValue(ctx, bypassResultKey{}, result)
+}
+
+func BypassResultFromContext(ctx context.Context) *BypassResult {
+	v, _ := ctx.Value(bypassResultKey{}).(*BypassResult)
+	return v
+}

--- a/internal/gostx/handler/http/handler.go
+++ b/internal/gostx/handler/http/handler.go
@@ -297,17 +297,32 @@ func (h *httpHandler) handleRequest(ctx context.Context, conn net.Conn, req *htt
 
 	ctx = xctx.ContextWithClientID(ctx, xctx.ClientID(clientID))
 
-	if h.options.Bypass != nil &&
-		h.options.Bypass.Contains(ctx, network, addr, bypass.WithService(h.options.Service)) {
-		resp.StatusCode = http.StatusForbidden
+	var bypassResult *xctx.BypassResult
+	if h.options.Bypass != nil {
+		bypassResult = &xctx.BypassResult{}
+		checkCtx := xctx.ContextWithBypassResult(ctx, bypassResult)
+		if h.options.Bypass.Contains(checkCtx, network, addr, bypass.WithService(h.options.Service)) {
+			resp.StatusCode = http.StatusForbidden
 
-		if log.IsLevelEnabled(logger.TraceLevel) {
-			dump, _ := httputil.DumpResponse(resp, false)
-			log.Trace(string(dump))
+			if log.IsLevelEnabled(logger.TraceLevel) {
+				dump, _ := httputil.DumpResponse(resp, false)
+				log.Trace(string(dump))
+			}
+			log.Debug("bypass: ", addr)
+			resp.Write(conn)
+			return xbypass.ErrBypass
 		}
-		log.Debug("bypass: ", addr)
-		resp.Write(conn)
-		return xbypass.ErrBypass
+
+		// Register this connection for cancellation if the rule is later deleted.
+		if bypassResult.RuleID != 0 && bypassResult.Tracker != nil {
+			var pipeCancel context.CancelFunc
+			ctx, pipeCancel = context.WithCancel(ctx)
+			connID := bypassResult.Tracker.Register(bypassResult.RuleID, pipeCancel)
+			defer func() {
+				bypassResult.Tracker.Unregister(bypassResult.RuleID, connID)
+				pipeCancel()
+			}()
+		}
 	}
 
 	if network == "udp" {

--- a/internal/gostx/handler/socks/v5/connect.go
+++ b/internal/gostx/handler/socks/v5/connect.go
@@ -56,7 +56,9 @@ func (h *socks5Handler) handleConnect(ctx context.Context, conn net.Conn, networ
 	}
 
 	if h.options.Bypass != nil {
-		bypassCtx, bypassCancel := context.WithCancel(ctx)
+		bypassResult := &xctx.BypassResult{}
+		resultCtx := xctx.ContextWithBypassResult(ctx, bypassResult)
+		bypassCtx, bypassCancel := context.WithCancel(resultCtx)
 
 		// Monitor the client TCP connection for close during the bypass check.
 		// During SOCKS5 CONNECT, the client waits for the server reply before
@@ -95,6 +97,17 @@ func (h *socks5Handler) handleConnect(ctx context.Context, conn net.Conn, networ
 			log.Trace(resp)
 			log.Debug("bypass: ", address)
 			return resp.Write(conn)
+		}
+
+		// Register this connection for cancellation if the rule is later deleted.
+		if bypassResult.RuleID != 0 && bypassResult.Tracker != nil {
+			var pipeCancel context.CancelFunc
+			ctx, pipeCancel = context.WithCancel(ctx)
+			connID := bypassResult.Tracker.Register(bypassResult.RuleID, pipeCancel)
+			defer func() {
+				bypassResult.Tracker.Unregister(bypassResult.RuleID, connID)
+				pipeCancel()
+			}()
 		}
 	}
 

--- a/internal/gostx/internal/net/pipe.go
+++ b/internal/gostx/internal/net/pipe.go
@@ -43,7 +43,11 @@ func Pipe(ctx context.Context, rw1, rw2 io.ReadWriteCloser) error {
 	select {
 	case <-done:
 	case <-ctx.Done():
-		return nil
+		// Close both sides to unblock the pipeBuffer goroutines.
+		rw1.Close()
+		rw2.Close()
+		<-done
+		return ctx.Err()
 	}
 
 	select {

--- a/internal/greyproxy/api/router.go
+++ b/internal/greyproxy/api/router.go
@@ -10,12 +10,13 @@ import (
 
 // Shared holds shared state passed to all handlers.
 type Shared struct {
-	DB      *greyproxy.DB
-	Cache   *greyproxy.DNSCache
-	Bus     *greyproxy.EventBus
-	Waiters *greyproxy.WaiterTracker
-	Version string
-	Ports   map[string]int
+	DB          *greyproxy.DB
+	Cache       *greyproxy.DNSCache
+	Bus         *greyproxy.EventBus
+	Waiters     *greyproxy.WaiterTracker
+	ConnTracker *greyproxy.ConnTracker
+	Version     string
+	Ports       map[string]int
 }
 
 // NewRouter creates the Gin router with all routes.

--- a/internal/greyproxy/api/rules.go
+++ b/internal/greyproxy/api/rules.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -81,6 +82,11 @@ func RulesUpdateHandler(s *Shared) gin.HandlerFunc {
 			return
 		}
 
+		// If the rule was changed to deny, cancel connections that relied on it.
+		if rule.Action == "deny" && s.ConnTracker != nil {
+			s.ConnTracker.CancelByRule(id)
+		}
+
 		c.JSON(http.StatusOK, rule.ToJSON())
 	}
 }
@@ -111,10 +117,17 @@ func RulesDeleteHandler(s *Shared) gin.HandlerFunc {
 			return
 		}
 
+		slog.Info("api: deleting rule", "rule_id", id)
+
 		deleted, err := greyproxy.DeleteRule(s.DB, id)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
+		}
+
+		slog.Info("api: rule deleted, cancelling connections", "rule_id", id, "deleted", deleted)
+		if deleted && s.ConnTracker != nil {
+			s.ConnTracker.CancelByRule(id)
 		}
 
 		c.JSON(http.StatusOK, gin.H{"status": "ok", "deleted": deleted})

--- a/internal/greyproxy/conn_tracker.go
+++ b/internal/greyproxy/conn_tracker.go
@@ -1,0 +1,76 @@
+package greyproxy
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+var nextConnID atomic.Uint64
+
+// ConnTracker tracks active proxy connections by the rule ID that authorized
+// them. When a rule is deleted or changed to deny, all connections that were
+// allowed by that rule can be cancelled immediately.
+type ConnTracker struct {
+	mu    sync.Mutex
+	conns map[int64]map[uint64]context.CancelFunc
+}
+
+func NewConnTracker() *ConnTracker {
+	return &ConnTracker{
+		conns: make(map[int64]map[uint64]context.CancelFunc),
+	}
+}
+
+// Register associates a cancel function with a rule ID and returns an ID
+// that can be used to unregister later.
+func (ct *ConnTracker) Register(ruleID int64, cancel context.CancelFunc) uint64 {
+	id := nextConnID.Add(1)
+
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if ct.conns[ruleID] == nil {
+		ct.conns[ruleID] = make(map[uint64]context.CancelFunc)
+	}
+	ct.conns[ruleID][id] = cancel
+
+	slog.Info("conn_tracker: registered", "conn_id", id, "rule_id", ruleID, "total_for_rule", len(ct.conns[ruleID]))
+	return id
+}
+
+// Unregister removes a previously registered connection.
+// Called when a connection ends naturally.
+func (ct *ConnTracker) Unregister(ruleID int64, id uint64) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if m, ok := ct.conns[ruleID]; ok {
+		delete(m, id)
+		if len(m) == 0 {
+			delete(ct.conns, ruleID)
+		}
+		slog.Info("conn_tracker: unregistered", "conn_id", id, "rule_id", ruleID)
+	}
+}
+
+// CancelByRule cancels all active connections that were authorized by the
+// given rule ID and removes them from tracking.
+func (ct *ConnTracker) CancelByRule(ruleID int64) {
+	ct.mu.Lock()
+	cancels := ct.conns[ruleID]
+	delete(ct.conns, ruleID)
+	ct.mu.Unlock()
+
+	if len(cancels) == 0 {
+		slog.Info("conn_tracker: cancel by rule, no active connections", "rule_id", ruleID)
+		return
+	}
+
+	slog.Info("conn_tracker: cancel by rule, killing connections", "rule_id", ruleID, "count", len(cancels))
+	for id, cancel := range cancels {
+		slog.Info("conn_tracker: cancelling conn", "conn_id", id, "rule_id", ruleID)
+		cancel()
+	}
+}

--- a/internal/greyproxy/conn_tracker_test.go
+++ b/internal/greyproxy/conn_tracker_test.go
@@ -1,0 +1,170 @@
+package greyproxy
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConnTrackerRegisterAndCancel(t *testing.T) {
+	ct := NewConnTracker()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ct.Register(42, cancel)
+
+	// Context should still be active
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should not be cancelled yet")
+	default:
+	}
+
+	// Cancel all connections for rule 42
+	ct.CancelByRule(42)
+
+	select {
+	case <-ctx.Done():
+		// OK
+	case <-time.After(time.Second):
+		t.Fatal("context should have been cancelled")
+	}
+}
+
+func TestConnTrackerMultipleConnsPerRule(t *testing.T) {
+	ct := NewConnTracker()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	ct.Register(42, cancel1)
+	ct.Register(42, cancel2)
+
+	ct.CancelByRule(42)
+
+	select {
+	case <-ctx1.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx1 should have been cancelled")
+	}
+
+	select {
+	case <-ctx2.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx2 should have been cancelled")
+	}
+}
+
+func TestConnTrackerUnregister(t *testing.T) {
+	ct := NewConnTracker()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	connID := ct.Register(42, cancel)
+	ct.Unregister(42, connID)
+
+	// After unregister, CancelByRule should have no effect
+	ct.CancelByRule(42)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should NOT have been cancelled after unregister")
+	default:
+		// OK
+	}
+}
+
+func TestConnTrackerCancelOnlyAffectsTargetRule(t *testing.T) {
+	ct := NewConnTracker()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	ct.Register(1, cancel1)
+	ct.Register(2, cancel2)
+
+	// Cancel only rule 1
+	ct.CancelByRule(1)
+
+	select {
+	case <-ctx1.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx1 should have been cancelled")
+	}
+
+	select {
+	case <-ctx2.Done():
+		t.Fatal("ctx2 should NOT have been cancelled")
+	default:
+		// OK
+	}
+}
+
+func TestConnTrackerCancelByRuleIdempotent(t *testing.T) {
+	ct := NewConnTracker()
+
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ct.Register(42, cancel)
+
+	// Calling CancelByRule twice should not panic
+	ct.CancelByRule(42)
+	ct.CancelByRule(42)
+}
+
+func TestConnTrackerUnregisterUnknown(t *testing.T) {
+	ct := NewConnTracker()
+
+	// Unregistering a non-existent rule/conn should not panic
+	ct.Unregister(999, 12345)
+}
+
+func TestConnTrackerConcurrent(t *testing.T) {
+	ct := NewConnTracker()
+
+	var wg sync.WaitGroup
+	var cancelled atomic.Int64
+
+	// Register 100 connections across 10 rules
+	for rule := int64(0); rule < 10; rule++ {
+		for i := 0; i < 10; i++ {
+			rule := rule
+			ctx, cancel := context.WithCancel(context.Background())
+			connID := ct.Register(rule, cancel)
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ctx.Done()
+				cancelled.Add(1)
+				ct.Unregister(rule, connID)
+			}()
+		}
+	}
+
+	// Cancel all rules concurrently
+	var cancelWg sync.WaitGroup
+	for rule := int64(0); rule < 10; rule++ {
+		rule := rule
+		cancelWg.Add(1)
+		go func() {
+			defer cancelWg.Done()
+			ct.CancelByRule(rule)
+		}()
+	}
+	cancelWg.Wait()
+	wg.Wait()
+
+	if got := cancelled.Load(); got != 100 {
+		t.Errorf("expected 100 cancelled connections, got %d", got)
+	}
+}

--- a/internal/greyproxy/plugins/bypass.go
+++ b/internal/greyproxy/plugins/bypass.go
@@ -20,19 +20,21 @@ import (
 // IMPORTANT: In gost's blacklist mode (IsWhitelist()=false),
 // Contains() returning true means BLOCK the connection.
 type Bypass struct {
-	db      *greyproxy.DB
-	cache   *greyproxy.DNSCache
-	bus     *greyproxy.EventBus
-	waiters *greyproxy.WaiterTracker
-	log     logger.Logger
+	db          *greyproxy.DB
+	cache       *greyproxy.DNSCache
+	bus         *greyproxy.EventBus
+	waiters     *greyproxy.WaiterTracker
+	connTracker *greyproxy.ConnTracker
+	log         logger.Logger
 }
 
-func NewBypass(db *greyproxy.DB, cache *greyproxy.DNSCache, bus *greyproxy.EventBus, waiters *greyproxy.WaiterTracker) *Bypass {
+func NewBypass(db *greyproxy.DB, cache *greyproxy.DNSCache, bus *greyproxy.EventBus, waiters *greyproxy.WaiterTracker, connTracker *greyproxy.ConnTracker) *Bypass {
 	return &Bypass{
-		db:      db,
-		cache:   cache,
-		bus:     bus,
-		waiters: waiters,
+		db:          db,
+		cache:       cache,
+		bus:         bus,
+		waiters:     waiters,
+		connTracker: connTracker,
 		log: logger.Default().WithFields(map[string]any{
 			"kind":   "bypass",
 			"bypass": "greyproxy",
@@ -92,6 +94,15 @@ func (b *Bypass) Contains(ctx context.Context, network, addr string, opts ...byp
 	}
 	// No rule = default deny (allowed stays false)
 
+	// Store the rule ID and conn tracker in the context's BypassResult
+	// so the handler can register the connection for cancellation.
+	if allowed && ruleID != nil {
+		if br := ctxvalue.BypassResultFromContext(ctx); br != nil {
+			br.RuleID = *ruleID
+			br.Tracker = b.connTracker
+		}
+	}
+
 	// If blocked by default (no matching rule), hold the connection and wait
 	// for the user to approve via the dashboard within the grace period.
 	if !allowed && !deniedByRule {
@@ -103,6 +114,10 @@ func (b *Bypass) Contains(ctx context.Context, network, addr string, opts ...byp
 		if rule := b.waitForApproval(ctx, containerName, host, port, resolvedHostname); rule != nil {
 			allowed = true
 			ruleID = &rule.ID
+			if br := ctxvalue.BypassResultFromContext(ctx); br != nil {
+				br.RuleID = rule.ID
+				br.Tracker = b.connTracker
+			}
 		}
 	}
 

--- a/internal/greyproxy/ui/pages.go
+++ b/internal/greyproxy/ui/pages.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+
 	"github.com/gin-gonic/gin"
 	greyproxy "github.com/greyhavenhq/greyproxy/internal/greyproxy"
 )
@@ -261,7 +263,7 @@ func RegisterPageRoutes(r *gin.RouterGroup, db *greyproxy.DB, bus *greyproxy.Eve
 }
 
 // RegisterHTMXRoutes registers the HTMX partial routes.
-func RegisterHTMXRoutes(r *gin.RouterGroup, db *greyproxy.DB, bus *greyproxy.EventBus, waiters *greyproxy.WaiterTracker) {
+func RegisterHTMXRoutes(r *gin.RouterGroup, db *greyproxy.DB, bus *greyproxy.EventBus, waiters *greyproxy.WaiterTracker, connTracker *greyproxy.ConnTracker) {
 	prefix := strings.TrimRight(r.BasePath(), "/")
 	htmx := r.Group("/htmx")
 
@@ -486,13 +488,21 @@ func RegisterHTMXRoutes(r *gin.RouterGroup, db *greyproxy.DB, bus *greyproxy.Eve
 			input.Notes = &notes
 		}
 
-		greyproxy.UpdateRule(db, id, input)
+		rule, _ := greyproxy.UpdateRule(db, id, input)
+		if rule != nil && rule.Action == "deny" && connTracker != nil {
+			connTracker.CancelByRule(id)
+		}
 		renderRulesList(c, db, prefix)
 	})
 
 	htmx.DELETE("/rules/:id", func(c *gin.Context) {
 		id, _ := strconv.ParseInt(c.Param("id"), 10, 64)
-		greyproxy.DeleteRule(db, id)
+		slog.Info("htmx: deleting rule", "rule_id", id)
+		deleted, _ := greyproxy.DeleteRule(db, id)
+		slog.Info("htmx: rule deleted, cancelling connections", "rule_id", id, "deleted", deleted)
+		if deleted && connTracker != nil {
+			connTracker.CancelByRule(id)
+		}
 		c.Status(http.StatusOK)
 	})
 


### PR DESCRIPTION
## Summary

- Adds a `ConnTracker` that maps rule IDs to active proxy connections, so deleting or denying a rule immediately kills all connections it authorized
- The bypass plugin writes the authorizing rule ID into the request context; SOCKS5 and HTTP CONNECT handlers register a cancellable context with the tracker
- `Pipe` now actively closes both sides of the tunnel on context cancellation, ensuring goroutines are unblocked
- API and HTMX rule handlers call `CancelByRule` on delete or deny actions

## Test plan

- [x] Unit tests for ConnTracker (register, unregister, cancel by rule, concurrent access)
- [x] Manual end-to-end: create allow rule, make request through proxy, delete rule, verify connection is killed and subsequent requests are blocked
- [x] Build passes, existing tests pass