### PR TITLE
fix: store expires_at in UTC format compatible with SQLite datetime()

### DIFF
--- a/internal/greyproxy/crud.go
+++ b/internal/greyproxy/crud.go
@@ -47,9 +47,10 @@ func CreateRule(db *DB, input RuleCreateInput) (*Rule, error) {
 		input.CreatedBy = "admin"
 	}
 
-	var expiresAt sql.NullTime
+	var expiresAt sql.NullString
 	if input.ExpiresInSeconds != nil && *input.ExpiresInSeconds > 0 {
-		expiresAt = sql.NullTime{Time: time.Now().Add(time.Duration(*input.ExpiresInSeconds) * time.Second), Valid: true}
+		t := time.Now().UTC().Add(time.Duration(*input.ExpiresInSeconds) * time.Second)
+		expiresAt = sql.NullString{String: t.Format("2006-01-02 15:04:05"), Valid: true}
 	}
 
 	var notes sql.NullString

--- a/internal/greyproxy/crud_test.go
+++ b/internal/greyproxy/crud_test.go
@@ -112,6 +112,42 @@ func TestCreateRuleWithExpiration(t *testing.T) {
 	}
 }
 
+func TestTemporaryRuleVisibleInGetRules(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Create a temporary rule with 1h expiry
+	expires := int64(3600)
+	_, err := CreateRule(db, RuleCreateInput{
+		ContainerPattern:   "myapp",
+		DestinationPattern: "example.com",
+		ExpiresInSeconds:   &expires,
+		Action:             "allow",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The rule should be visible in GetRules (not filtered as expired)
+	rules, total, err := GetRules(db, RuleFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 rule, got %d (temporary rule incorrectly filtered as expired)", total)
+	}
+	if len(rules) != 1 {
+		t.Errorf("expected 1 rule in list, got %d", len(rules))
+	}
+
+	// The rule should also be found by FindMatchingRule
+	found := FindMatchingRule(db, "myapp", "example.com", 443, "")
+	if found == nil {
+		t.Error("expected FindMatchingRule to find the temporary rule")
+	} else if found.Action != "allow" {
+		t.Errorf("expected allow action, got %s", found.Action)
+	}
+}
+
 func TestGetRules(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/greyproxy/ui/templates/partials/pending_list.html
+++ b/internal/greyproxy/ui/templates/partials/pending_list.html
@@ -106,11 +106,13 @@
                         <!-- Dropdown menu -->
                         <div id="allow-menu-{{.ID}}" class="hidden absolute right-0 top-full mt-1 w-40 bg-card rounded-md shadow-lg border border-border z-50">
                             <div class="py-1">
+                                {{if gt .WaitingCount 0}}
                                 <button hx-post="{{$.Prefix}}/htmx/pending/{{.ID}}/allow" hx-vals='{"scope": "exact", "duration": "once"}'
                                     hx-target="#pending-list" hx-swap="innerHTML"
                                     class="btn-menu-item w-full text-left px-3 py-1.5 text-xs text-foreground hover:bg-muted transition-colors">
                                     Allow this time
                                 </button>
+                                {{end}}
                                 <button hx-post="{{$.Prefix}}/htmx/pending/{{.ID}}/allow" hx-vals='{"scope": "exact", "duration": "1h"}'
                                     hx-target="#pending-list" hx-swap="innerHTML"
                                     class="btn-menu-item w-full text-left px-3 py-1.5 text-xs text-foreground hover:bg-muted transition-colors">


### PR DESCRIPTION
## Summary

- **Fix**: `expires_at` was stored using Go's `sql.NullTime` which serializes in Go's default format (local timezone + monotonic clock suffix like `2026-03-09 12:41:15.506916967 -0600 CST m=+4177...`). All SQL queries compare with SQLite's `datetime('now')` (UTC, format `2026-03-09 17:41:15`), so the text comparison failed in non-UTC timezones -- temporary rules appeared expired immediately after creation.
- **Impact**: "Allow this time", "Allow for 1h", "Allow for 12h" all created rules that were invisible to `FindMatchingRule` and `GetRules`, so waiting connections were never released and rules didn't show up on the rules page.
- **UI**: Hide "Allow this time" option when no connections are actively waiting (WaitingCount == 0), since the 30s rule only makes sense during the grace period.

## Test plan

- [x] All existing tests pass
- [x] New regression test `TestTemporaryRuleVisibleInGetRules` verifies temporary rules are found by both `GetRules` and `FindMatchingRule`
- [x] Manual integration test: "Allow for 1h" now creates a visible rule and releases the waiting connection
- [x] Manual integration test: "Allow this time" creates a 30s rule, releases the connection, rule auto-expires