### PR TITLE
feat: graceful fallback for older notify-send versions

### DIFF
--- a/internal/greyproxy/api/settings.go
+++ b/internal/greyproxy/api/settings.go
@@ -13,10 +13,11 @@ type settingsResponse struct {
 }
 
 type notificationSettingsResp struct {
-	Enabled     bool   `json:"enabled"`
-	Available   bool   `json:"available"`
-	Backend     string `json:"backend"`
-	InstallHint string `json:"installHint,omitempty"`
+	Enabled         bool   `json:"enabled"`
+	Available       bool   `json:"available"`
+	Backend         string `json:"backend"`
+	InstallHint     string `json:"installHint,omitempty"`
+	SupportsActions bool   `json:"supportsActions"`
 }
 
 func buildSettingsResponse(s *Shared) settingsResponse {
@@ -30,10 +31,11 @@ func buildSettingsResponse(s *Shared) settingsResponse {
 	return settingsResponse{
 		Theme: resolved.Theme,
 		Notifications: notificationSettingsResp{
-			Enabled:     resolved.NotificationsEnabled,
-			Available:   info.Available,
-			Backend:     info.Backend,
-			InstallHint: info.InstallHint,
+			Enabled:         resolved.NotificationsEnabled,
+			Available:       info.Available,
+			Backend:         info.Backend,
+			InstallHint:     info.InstallHint,
+			SupportsActions: info.SupportsActions,
 		},
 	}
 }

--- a/internal/greyproxy/notifier.go
+++ b/internal/greyproxy/notifier.go
@@ -35,6 +35,8 @@ type Notifier struct {
 
 	// Which notification backend to use (detected at startup).
 	backend notifyBackend
+	// Capabilities of the notify-send binary (Linux only).
+	linuxCaps notifySendCaps
 
 	// Track when we last notified per pending key (container|host|port),
 	// so we can suppress rapid re-notifications.
@@ -59,11 +61,19 @@ const (
 	backendTerminalNotifier
 )
 
+// notifySendCaps tracks which features the installed notify-send supports.
+// Versions < 0.8 (e.g. Ubuntu 22.04's 0.7.9) lack -w, -A, -r, -p.
+type notifySendCaps struct {
+	wait    bool // -w (block until closed/clicked)
+	actions bool // -A (clickable actions)
+}
+
 // NotificationBackendInfo describes the notification backend status.
 type NotificationBackendInfo struct {
-	Available   bool   `json:"available"`
-	Backend     string `json:"backend"`
-	InstallHint string `json:"installHint,omitempty"`
+	Available      bool   `json:"available"`
+	Backend        string `json:"backend"`
+	InstallHint    string `json:"installHint,omitempty"`
+	SupportsActions bool   `json:"supportsActions"`
 }
 
 func NewNotifier(bus *EventBus, db *DB, enabled bool, dashboardURL string) *Notifier {
@@ -78,6 +88,9 @@ func NewNotifier(bus *EventBus, db *DB, enabled bool, dashboardURL string) *Noti
 	}
 	n.enabled.Store(enabled)
 	n.backend = detectBackend()
+	if n.backend == backendNotifySend {
+		n.linuxCaps = detectNotifySendCaps()
+	}
 	return n
 }
 
@@ -105,7 +118,46 @@ func (n *Notifier) BackendInfo() NotificationBackendInfo {
 	if !info.Available {
 		info.InstallHint = installHint()
 	}
+	// terminal-notifier on macOS always supports actions.
+	info.SupportsActions = n.backend == backendTerminalNotifier || n.linuxCaps.actions
 	return info
+}
+
+// detectNotifySendCaps parses the version from `notify-send --version` and
+// determines which features are available. Versions >= 0.8 support -w and -A.
+func detectNotifySendCaps() notifySendCaps {
+	out, err := exec.Command("notify-send", "--version").Output()
+	if err != nil {
+		return notifySendCaps{}
+	}
+
+	// Output looks like "notify-send 0.8.3" or "notify-send 0.7.9".
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) < 2 {
+		return notifySendCaps{}
+	}
+
+	version := parts[len(parts)-1]
+	major, minor := parseVersion(version)
+
+	// -w and -A were introduced in libnotify 0.8.0.
+	advanced := major > 0 || (major == 0 && minor >= 8)
+	return notifySendCaps{
+		wait:    advanced,
+		actions: advanced,
+	}
+}
+
+// parseVersion extracts major.minor from a version string like "0.8.3".
+func parseVersion(v string) (major, minor int) {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) >= 1 {
+		fmt.Sscanf(parts[0], "%d", &major)
+	}
+	if len(parts) >= 2 {
+		fmt.Sscanf(parts[1], "%d", &minor)
+	}
+	return
 }
 
 func installHint() string {
@@ -163,7 +215,10 @@ func (n *Notifier) Start() {
 		}
 	}()
 
-	n.log.Infof("notifier started (enabled=%v, backend=%v)", n.enabled.Load(), n.backendName())
+	if n.backend == backendNotifySend && !n.linuxCaps.actions {
+		n.log.Warn("notify-send < 0.8 detected; running in basic mode (no click actions or auto-dismiss)")
+	}
+	n.log.Infof("notifier started (enabled=%v, backend=%v, actions=%v)", n.enabled.Load(), n.backendName(), n.linuxCaps.actions || n.backend == backendTerminalNotifier)
 }
 
 func (n *Notifier) backendName() string {
@@ -361,6 +416,17 @@ func (n *Notifier) sendNotification(title, body, url string, pendingID int64) {
 }
 
 func (n *Notifier) sendLinux(title, body, url string, pendingID int64) {
+	if n.linuxCaps.wait && n.linuxCaps.actions {
+		n.sendLinuxAdvanced(title, body, url, pendingID)
+	} else {
+		n.sendLinuxBasic(title, body, pendingID)
+	}
+}
+
+// sendLinuxAdvanced uses -w and -A (notify-send >= 0.8).
+// The process blocks until the notification is closed or clicked,
+// so we can track the PID and close it with SIGINT on resolution.
+func (n *Notifier) sendLinuxAdvanced(title, body, url string, pendingID int64) {
 	go func() {
 		cmd := exec.Command("notify-send",
 			"-a", "greyproxy",
@@ -397,6 +463,25 @@ func (n *Notifier) sendLinux(title, body, url string, pendingID int64) {
 
 		cmd.Wait()
 		n.untrackNotification(pendingID)
+	}()
+}
+
+// sendLinuxBasic is the fallback for notify-send < 0.8 (e.g. Ubuntu 22.04).
+// It fires a simple notification without waiting or actions. The process
+// exits immediately, so we cannot track it or close it programmatically.
+func (n *Notifier) sendLinuxBasic(title, body string, pendingID int64) {
+	go func() {
+		cmd := exec.Command("notify-send",
+			"-a", "greyproxy",
+			"-u", "normal",
+			"-c", "network",
+			"-t", "30000",
+			title,
+			body,
+		)
+		if err := cmd.Run(); err != nil {
+			n.log.Debugf("notify-send (basic): %v", err)
+		}
 	}()
 }
 

--- a/internal/greyproxy/notifier_test.go
+++ b/internal/greyproxy/notifier_test.go
@@ -1,0 +1,70 @@
+package greyproxy
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantMajor int
+		wantMinor int
+	}{
+		{"0.7.9", 0, 7},
+		{"0.8.3", 0, 8},
+		{"0.8.6", 0, 8},
+		{"0.8.8", 0, 8},
+		{"1.0.0", 1, 0},
+		{"0.8", 0, 8},
+		{"2", 2, 0},
+		{"", 0, 0},
+		{"abc", 0, 0},
+	}
+
+	for _, tt := range tests {
+		major, minor := parseVersion(tt.input)
+		if major != tt.wantMajor || minor != tt.wantMinor {
+			t.Errorf("parseVersion(%q) = (%d, %d), want (%d, %d)",
+				tt.input, major, minor, tt.wantMajor, tt.wantMinor)
+		}
+	}
+}
+
+func TestDetectNotifySendCaps(t *testing.T) {
+	// detectNotifySendCaps calls the real notify-send binary, so we
+	// can only run a meaningful assertion when it is installed. When
+	// it is not installed the function returns the zero-value caps,
+	// which is still a valid (and safe) result.
+	caps := detectNotifySendCaps()
+
+	// wait and actions are always set together.
+	if caps.wait != caps.actions {
+		t.Errorf("expected wait and actions to match, got wait=%v actions=%v",
+			caps.wait, caps.actions)
+	}
+}
+
+// TestNotifySendCapsFromVersion verifies the version-to-capability logic
+// by exercising parseVersion against the thresholds used in detectNotifySendCaps.
+func TestNotifySendCapsFromVersion(t *testing.T) {
+	tests := []struct {
+		version     string
+		wantAdvanced bool
+	}{
+		{"0.7.9", false},
+		{"0.7.0", false},
+		{"0.6.1", false},
+		{"0.8.0", true},
+		{"0.8.3", true},
+		{"0.8.6", true},
+		{"0.8.8", true},
+		{"1.0.0", true},
+		{"2.1.3", true},
+	}
+
+	for _, tt := range tests {
+		major, minor := parseVersion(tt.version)
+		advanced := major > 0 || (major == 0 && minor >= 8)
+		if advanced != tt.wantAdvanced {
+			t.Errorf("version %q: advanced=%v, want %v", tt.version, advanced, tt.wantAdvanced)
+		}
+	}
+}

--- a/internal/greyproxy/ui/templates/settings.html
+++ b/internal/greyproxy/ui/templates/settings.html
@@ -61,6 +61,19 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Basic mode hint (shown when notify-send is old and lacks actions) -->
+            <div id="notif-basic-hint" class="hidden mt-4 p-4 bg-muted rounded-lg border border-border">
+                <div class="flex items-start gap-3">
+                    <svg class="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                    </svg>
+                    <div>
+                        <p class="font-medium text-foreground">Running in basic mode</p>
+                        <p class="mt-1 text-muted-foreground">Your version of notify-send does not support click actions or auto-dismiss. Notifications will still appear, but you will need to use the dashboard to act on them. Upgrade libnotify to 0.8+ for full functionality.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -147,17 +160,25 @@
         var statusEl = document.getElementById('notif-status');
         var hintEl = document.getElementById('notif-install-hint');
         var hintTextEl = document.getElementById('notif-install-text');
+        var basicHintEl = document.getElementById('notif-basic-hint');
 
         if (!data.available) {
             statusEl.innerHTML = '<span class="text-muted-foreground">No notification backend available</span>';
             hintEl.classList.remove('hidden');
+            basicHintEl.classList.add('hidden');
             hintTextEl.textContent = data.installHint || 'Desktop notifications are not supported on this platform.';
         } else {
             var status = data.enabled ? 'Enabled' : 'Disabled';
             var statusColor = data.enabled ? 'text-[var(--color-green)]' : 'text-muted-foreground';
-            statusEl.innerHTML = '<span class="' + statusColor + '">' + status + '</span>' +
+            var mode = data.supportsActions ? '' : ' (basic)';
+            statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + '</span>' +
                 ' <span class="text-muted-foreground">&middot; Using ' + data.backend + '</span>';
             hintEl.classList.add('hidden');
+            if (!data.supportsActions && data.enabled) {
+                basicHintEl.classList.remove('hidden');
+            } else {
+                basicHintEl.classList.add('hidden');
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Detect `notify-send` version at startup and fall back to a basic fire-and-forget notification for versions < 0.8 (e.g. Ubuntu 22.04's 0.7.9) that lack `-w` and `-A` flags
- Expose `supportsActions` in the settings API so the frontend can communicate reduced capabilities
- Show a "Running in basic mode" hint in the settings UI when click actions and auto-dismiss are unavailable
- Add tests for version parsing and capability detection

## Context

A survey of `notify-send` across distros revealed that Ubuntu 22.04 ships v0.7.9, which lacks `-w` (wait) and `-A` (actions). The previous implementation used both flags unconditionally, causing `notify-send` to fail entirely on older systems.

| Version | Distro | `-w` / `-A` |
|---------|--------|-------------|
| 0.7.9 | Ubuntu 22.04 | No |
| 0.8.3 | Ubuntu 24.04, Pop!_OS 24.04 | Yes |
| 0.8.6 | Ubuntu 25.10 | Yes |
| 0.8.8 | Arch | Yes |

## Test plan

- [ ] Verify `go test ./internal/greyproxy/ -run TestParseVersion` passes
- [ ] Verify `go test ./internal/greyproxy/ -run TestNotifySendCapsFromVersion` passes
- [ ] On a system with notify-send >= 0.8: confirm notifications have click-to-open and auto-dismiss
- [ ] On a system with notify-send < 0.8 (or by mocking): confirm basic notifications fire without errors
- [ ] Check the settings page shows "(basic)" and the info box on older versions