### PR TITLE
feat: Homebrew tap formula for greyproxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
-          # distribution:
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,6 +71,25 @@ changelog:
       - '^docs:'
       - '^test:'
 
+brews:
+  - repository:
+      owner: GreyhavenHQ
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/GreyhavenHQ/greyproxy"
+    description: "SOCKS5 proxy with DNS resolution and web dashboard for network sandboxing"
+    license: "Apache-2.0"
+    dependencies:
+      - name: terminal-notifier
+        type: optional
+    install: |
+      bin.install "greyproxy"
+    caveats: |
+      For desktop notifications on macOS, install terminal-notifier:
+        brew install terminal-notifier
+    test: |
+      system bin/"greyproxy", "-V"
+
 release:
   prerelease: auto
   mode: keep-existing


### PR DESCRIPTION
## Summary
- Adds `brews` section to `.goreleaser.yaml` so each release auto-publishes a formula to `GreyhavenHQ/homebrew-tap`
- Includes `terminal-notifier` as optional dependency for macOS desktop notifications

## Context
This is step 1 of the Homebrew distribution setup. Order of operations:
1. **This PR** (greyproxy formula)
2. Release greyproxy (populates the tap with the `greyproxy` formula)
3. PR for greywall (formula + brew-aware `check`/`setup` commands)
4. Release greywall (populates the tap with the `greywall` formula, which `depends_on "greyproxy"`)