### PR TITLE
fix: migrate from deprecated brews to homebrew_casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,7 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brews:
+homebrew_casks:
   - repository:
       owner: GreyhavenHQ
       name: homebrew-tap
@@ -79,16 +79,13 @@ brews:
     homepage: "https://github.com/GreyhavenHQ/greyproxy"
     description: "SOCKS5 proxy with DNS resolution and web dashboard for network sandboxing"
     license: "Apache-2.0"
+    binaries:
+      - greyproxy
     dependencies:
-      - name: terminal-notifier
-        type: optional
-    install: |
-      bin.install "greyproxy"
+      - formula: terminal-notifier
     caveats: |
       For desktop notifications on macOS, install terminal-notifier:
         brew install terminal-notifier
-    test: |
-      system bin/"greyproxy", "-V"
 
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary
- Migrates `.goreleaser.yaml` from deprecated `brews` to `homebrew_casks`
- GoReleaser v2.10+ deprecated `brews`; Casks are the correct way to distribute pre-built binaries

## Context
v0.2.7 was released with `brews` and worked (with a deprecation warning). This PR removes the warning for future releases.

## Test plan
- [ ] Merge and release a new version
- [ ] Verify no deprecation warning in GoReleaser output
- [ ] Verify cask appears in `GreyhavenHQ/homebrew-tap/Casks/`