### PR TITLE
fix: prevent resolver from overwriting DNS cache hostname entries

### DIFF
--- a/internal/greyproxy/plugins/resolver.go
+++ b/internal/greyproxy/plugins/resolver.go
@@ -40,14 +40,19 @@ func (r *Resolver) Resolve(ctx context.Context, network, host string, opts ...re
 		return nil, fmt.Errorf("resolve %s: no results", host)
 	}
 
-	// Cache all resolved IPs -> hostname
-	ipStrs := make([]string, len(ips))
-	for i, ip := range ips {
-		ipStrs[i] = ip.String()
+	// Cache all resolved IPs -> hostname, but only when host is an actual
+	// hostname (not an IP). When gost calls the resolver with a raw IP,
+	// LookupIP returns the IP itself; registering it would overwrite
+	// a correct hostname entry previously populated by the DNS handler.
+	if net.ParseIP(host) == nil {
+		ipStrs := make([]string, len(ips))
+		for i, ip := range ips {
+			ipStrs[i] = ip.String()
+		}
+		r.cache.RegisterIPs(host, ipStrs)
 	}
-	r.cache.RegisterIPs(host, ipStrs)
 
-	r.log.Debugf("resolved %s -> %v", host, ipStrs)
+	r.log.Debugf("resolved %s -> %v", host, ips)
 	return ips, nil
 }
 


### PR DESCRIPTION
## Summary

- When gost calls the resolver plugin with a raw IP address (common with tun2socks transparent proxying), `net.LookupIP` returns the IP itself. `RegisterIPs` then overwrites the correct hostname mapping (e.g. `160.79.104.10 -> api.anthropic.com`) with a self-referential one (`160.79.104.10 -> 160.79.104.10`).
- This caused pending requests and request logs to progressively show raw IPs instead of hostnames, as each allowed connection corrupted its own cache entry.
- Fix: skip `RegisterIPs` when the host is already an IP address.

## Root cause

The DNS cache is populated correctly by the DNS handler wrapper (`dns_cache_handler.go`) when a DNS query flows through the proxy. However, once the connection is allowed and gost dials the destination, gost calls the resolver plugin to "resolve" the target. For IP destinations, `LookupIP("160.79.104.10")` trivially returns `[160.79.104.10]`, and `RegisterIPs("160.79.104.10", ...)` overwrites the correct entry.

Reproduction:
1. DNS query through proxy: `api.anthropic.com -> 160.79.104.10` (cache correct)
2. First SOCKS5 connection to `160.79.104.10`: cache HIT, shows `api.anthropic.com` (correct)
3. Resolver called during dial: overwrites cache with `160.79.104.10 -> 160.79.104.10`
4. Second SOCKS5 connection to `160.79.104.10`: cache HIT, shows `160.79.104.10` (wrong)

## Test plan

- [x] `go test ./internal/greyproxy/...` passes
- [x] Manual test: DNS query + 3 sequential SOCKS5 connections all show correct hostname after fix (previously the 2nd+ connections showed raw IP)