### PR TITLE
fix: bulk dismiss uses POST so HTMX sends checkbox values

### DIFF
--- a/internal/greyproxy/ui/pages.go
+++ b/internal/greyproxy/ui/pages.go
@@ -417,7 +417,7 @@ func RegisterHTMXRoutes(r *gin.RouterGroup, db *greyproxy.DB, bus *greyproxy.Eve
 	})
 
 	// Bulk dismiss via HTMX
-	htmx.DELETE("/pending/bulk-dismiss", func(c *gin.Context) {
+	htmx.POST("/pending/bulk-dismiss", func(c *gin.Context) {
 		ids := c.PostFormArray("selected")
 		for _, idStr := range ids {
 			id, err := strconv.ParseInt(idStr, 10, 64)

--- a/internal/greyproxy/ui/templates/pending.html
+++ b/internal/greyproxy/ui/templates/pending.html
@@ -51,7 +51,7 @@
             <div class="space-x-2">
                 <button hx-post="{{.Prefix}}/htmx/pending/bulk-allow" hx-include="[name='selected']:checked" hx-target="#pending-list" hx-swap="innerHTML"
                     class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-primary-foreground bg-primary hover:bg-primary/90">Allow Selected</button>
-                <button hx-delete="{{.Prefix}}/htmx/pending/bulk-dismiss" hx-include="[name='selected']:checked" hx-target="#pending-list" hx-swap="innerHTML"
+                <button hx-post="{{.Prefix}}/htmx/pending/bulk-dismiss" hx-include="[name='selected']:checked" hx-target="#pending-list" hx-swap="innerHTML"
                     class="inline-flex items-center px-4 py-2 border border-border text-sm font-medium rounded-md text-secondary-foreground bg-background hover:bg-muted">Dismiss Selected</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- The "Dismiss Selected" bulk action on the pending requests page was silently doing nothing
- Root cause: `hx-delete` does not send `hx-include` checkbox values in the request body, so `c.PostFormArray("selected")` always returned empty
- Changed both the HTMX button (`hx-delete` -> `hx-post`) and the Go route registration (`DELETE` -> `POST`) to match the working bulk-allow pattern

## Test plan
- [x] Select multiple pending requests and click "Dismiss Selected"; verify they are dismissed
- [x] Verify "Select All" + "Dismiss Selected" works
- [x] Verify "Select All" + "Allow Selected" still works as before