### PR TITLE
fix: include CA cert in TLS chain and use explicit trust policies on macOS

### DIFF
--- a/cmd/greyproxy/cert.go
+++ b/cmd/greyproxy/cert.go
@@ -196,7 +196,7 @@ func handleCertInstall(force bool) {
 
 		fmt.Println("Installing CA certificate into system trust store (requires sudo)...")
 		cmd := exec.Command("sudo", "security", "add-trusted-cert",
-			"-d", "-r", "trustRoot",
+			"-d", "-p", "ssl", "-p", "basic",
 			"-k", "/Library/Keychains/System.keychain",
 			certFile,
 		)
@@ -205,7 +205,7 @@ func handleCertInstall(force bool) {
 		cmd.Stdin = os.Stdin
 		if err := cmd.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "\nAutomatic install failed. Please run manually:\n\n")
-			fmt.Fprintf(os.Stderr, "  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \"%s\"\n\n", certFile)
+			fmt.Fprintf(os.Stderr, "  sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain \"%s\"\n\n", certFile)
 			os.Exit(1)
 		}
 		fmt.Printf("CA certificate installed and trusted in %s\n", certInstallLocation())

--- a/internal/gostx/internal/util/sniffing/sniffer.go
+++ b/internal/gostx/internal/util/sniffing/sniffer.go
@@ -928,7 +928,7 @@ func (h *Sniffer) terminateTLS(ctx context.Context, network string, conn, cc net
 			}
 
 			return &tls.Certificate{
-				Certificate: [][]byte{cert.Raw},
+				Certificate: [][]byte{cert.Raw, h.Certificate.Raw},
 				PrivateKey:  h.PrivateKey,
 			}, nil
 		},
@@ -1025,7 +1025,7 @@ func (h *Sniffer) terminateTLSDeferred(ctx context.Context, network string, conn
 				return nil, err
 			}
 			return &tls.Certificate{
-				Certificate: [][]byte{cert.Raw},
+				Certificate: [][]byte{cert.Raw, h.Certificate.Raw},
 				PrivateKey:  h.PrivateKey,
 			}, nil
 		},

--- a/internal/greyproxy/api/cert.go
+++ b/internal/greyproxy/api/cert.go
@@ -70,7 +70,7 @@ func buildInstallCommands(certPath string) map[string]string {
 	cmds := make(map[string]string)
 	switch runtime.GOOS {
 	case "darwin":
-		cmds["macos"] = fmt.Sprintf("sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \"%s\"", certPath)
+		cmds["macos"] = fmt.Sprintf("sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain \"%s\"", certPath)
 	case "linux":
 		destPath, updateCmd := linuxCertInstallInfo()
 		cmds["linux"] = fmt.Sprintf("sudo cp \"%s\" %s && sudo %s", certPath, destPath, updateCmd)


### PR DESCRIPTION
## Summary
- **TLS chain fix**: MITM handshake now sends both leaf cert and CA cert in the chain (`[][]byte{cert.Raw, h.Certificate.Raw}`), fixing "unable to get local issuer certificate" errors from clients that need the full chain to verify
- **macOS trust policy fix**: `cert install` now uses `-p ssl -p basic` instead of `-r trustRoot`, setting explicit per-policy trust settings in the Keychain — matching the approach used by mitmproxy. This ensures LibreSSL/curl properly honor the Keychain trust when verifying certificates through HTTP CONNECT tunnels
- Both normal and deferred TLS paths are fixed

## Context
macOS system curl uses LibreSSL which requires explicit trust policy entries in the Keychain (not just the default implicit trust from `-r trustRoot`). Without explicit policies, curl falls back to `/etc/ssl/cert.pem` and fails to find the CA.

A companion PR in greywall adds the `com.apple.TrustEvaluationAgent` Mach service and necessary filesystem paths to the sandbox profile so sandboxed apps can also verify certificates.

## Test plan
- [x] `greyproxy cert generate -f && greyproxy cert install -f`
- [x] `greyproxy serve` then `curl --proxy http://curl:proxy@localhost:43051 https://monadical.com` → should get HTTP 200
- [x] `greywall -- curl https://monadical.com` → should get HTTP 200 (requires greywall sandbox fix)
