### PR TITLE
fix: handle new string-encoded JSON metadata for session ID

### DIFF
--- a/internal/greyproxy/conversation_assembler.go
+++ b/internal/greyproxy/conversation_assembler.go
@@ -19,7 +19,7 @@ import (
 // that requires reprocessing existing conversations (e.g. new fields, linking).
 // When the stored version differs from this constant, the settings page
 // offers a "Rebuild conversations" action.
-const AssemblerVersion = 3
+const AssemblerVersion = 4
 
 // ConversationAssembler subscribes to EventTransactionNew and reassembles
 // LLM conversations from HTTP transactions using registered dissectors.
@@ -327,8 +327,11 @@ func (a *ConversationAssembler) loadTransactionsForSessions(sessionIDs map[strin
 	var likeClauses []string
 	var args []any
 	for sid := range sessionIDs {
-		likeClauses = append(likeClauses, `CAST(request_body AS TEXT) LIKE ? ESCAPE '\'`)
+		// Match both legacy format (session_UUID) and new JSON format (session_id with UUID value)
+		clause := `(CAST(request_body AS TEXT) LIKE ? ESCAPE '\' OR CAST(request_body AS TEXT) LIKE ? ESCAPE '\')`
+		likeClauses = append(likeClauses, clause)
 		args = append(args, "%session_"+escapeLikePattern(sid)+"%")
+		args = append(args, "%session_id%"+escapeLikePattern(sid)+"%")
 	}
 
 	query := fmt.Sprintf(`

--- a/internal/greyproxy/dissector/anthropic.go
+++ b/internal/greyproxy/dissector/anthropic.go
@@ -37,6 +37,7 @@ import (
 
 var sessionIDPattern = regexp.MustCompile(`session_([a-f0-9-]{36})`)
 var sessionIDJSONPattern = regexp.MustCompile(`"session_id"\s*:\s*"([a-f0-9-]{36})"`)
+var sessionIDEscapedJSONPattern = regexp.MustCompile(`\\?"session_id\\?"\s*:\\?\s*\\?"([a-f0-9-]{36})\\?"`)
 
 
 // AnthropicDissector parses Anthropic Messages API transactions.
@@ -205,15 +206,24 @@ func extractSessionIDFromUserID(raw json.RawMessage) string {
 		return ""
 	}
 
-	// Try as string first (legacy format)
+	// Try as string first (legacy format or JSON-encoded object)
 	var s string
 	if json.Unmarshal(raw, &s) == nil && s != "" {
+		// Legacy format: "user_HASH_account_UUID_session_UUID"
 		if m := sessionIDPattern.FindStringSubmatch(s); len(m) > 1 {
 			return m[1]
 		}
+		// New format: user_id is a JSON string containing a JSON object
+		// e.g. "{\"session_id\":\"UUID\",\"device_id\":\"...\"}"
+		var inner struct {
+			SessionID string `json:"session_id"`
+		}
+		if json.Unmarshal([]byte(s), &inner) == nil && inner.SessionID != "" {
+			return inner.SessionID
+		}
 	}
 
-	// Try as object with session_id field
+	// Try as object with session_id field (direct JSON object, not string-encoded)
 	var obj struct {
 		SessionID string `json:"session_id"`
 	}
@@ -228,8 +238,12 @@ func extractSessionIDFromRaw(body string) string {
 	if m := sessionIDPattern.FindStringSubmatch(body); len(m) > 1 {
 		return m[1]
 	}
-	// Also try "session_id":"UUID" pattern (new metadata format in raw JSON)
+	// Try "session_id":"UUID" pattern (new metadata format in raw JSON)
 	if m := sessionIDJSONPattern.FindStringSubmatch(body); len(m) > 1 {
+		return m[1]
+	}
+	// Try escaped variant: \"session_id\":\"UUID\" (string-encoded JSON in body)
+	if m := sessionIDEscapedJSONPattern.FindStringSubmatch(body); len(m) > 1 {
 		return m[1]
 	}
 	return ""

--- a/internal/greyproxy/dissector/anthropic_test.go
+++ b/internal/greyproxy/dissector/anthropic_test.go
@@ -184,6 +184,11 @@ func TestExtractSessionIDFromUserID(t *testing.T) {
 			"9d4a2584-4176-4653-be44-7d5f270feb21",
 		},
 		{
+			"string-encoded json object",
+			`"{\"device_id\":\"d8c2852a\",\"account_uuid\":\"5a3241c6-4cbe-47e2-a7d3-981f6bf69be8\",\"session_id\":\"9d4a2584-4176-4653-be44-7d5f270feb21\"}"`,
+			"9d4a2584-4176-4653-be44-7d5f270feb21",
+		},
+		{
 			"empty",
 			`""`,
 			"",


### PR DESCRIPTION
## Summary
- Claude Code now sends `metadata.user_id` as a JSON string containing a JSON object (`"{\"session_id\":\"UUID\"}"`) instead of the legacy `user_HASH_session_UUID` format
- This broke both session ID extraction and the LIKE-based session reload query, preventing conversation assembly entirely
- Fixes `extractSessionIDFromUserID` to parse the string-encoded JSON object, and updates `loadTransactionsForSessions` to match both `session_UUID` and `session_id%UUID` patterns
- Both legacy and new formats are supported; assembler version bumped to 4 to trigger rebuild

## Test plan
- [x] New test case for string-encoded JSON object format passes
- [x] All existing dissector and assembler tests pass
- [ ] Verified end-to-end: conversation created from real `?beta=true` traffic in local DB