### PR TITLE
feat:beta channel and live MITM cert reload

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,6 +76,7 @@ homebrew_casks:
       owner: GreyhavenHQ
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    skip_upload: auto
     homepage: "https://github.com/GreyhavenHQ/greyproxy"
     description: "SOCKS5 proxy with DNS resolution and web dashboard for network sandboxing"
     license: "Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,12 @@ all-arch: $(PLATFORM_LIST) $(WINDOWS_ARCH_LIST)
 releases: $(gz_releases) $(zip_releases)
 clean:
 	rm $(BINDIR)/*
+
+release:
+	@./scripts/release.sh patch
+
+release-minor:
+	@./scripts/release.sh minor
+
+release-beta:
+	@./scripts/release.sh beta

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ cd greyproxy
 go build ./cmd/greyproxy
 ```
 
+**macOS only:** after building, codesign the binary to avoid Gatekeeper quarantine:
+
+```bash
+codesign --sign - --force ./greyproxy
+```
+
+Install the binary and register it as a service:
+
+```bash
+./greyproxy install
+```
+
+This copies the binary to `~/.local/bin/`, registers a launchd user agent (macOS) or systemd user service (Linux), and starts it automatically. The dashboard will be available at `http://localhost:43080`.
+
+Generate and install the CA certificate for HTTPS inspection:
+
+```bash
+greyproxy cert generate
+greyproxy cert install
+```
+
+Alternatively, use [`greywall setup`](https://github.com/GreyhavenHQ/greywall) to handle the full build and install automatically.
+
 ### Install
 
 Install the binary to `~/.local/bin/` and register it as a systemd user service:

--- a/cmd/greyproxy/cert.go
+++ b/cmd/greyproxy/cert.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"math/big"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,6 +28,7 @@ Commands:
   generate    Generate CA certificate and key pair
   install     Trust the CA certificate on the OS
   uninstall   Remove the CA certificate from the OS trust store
+  reload      Reload the CA certificate in the running greyproxy (no restart needed)
 
 Options:
   -f          Force overwrite existing files (generate, install)
@@ -40,6 +45,8 @@ Options:
 		handleCertInstall(force)
 	case "uninstall":
 		handleCertUninstall()
+	case "reload":
+		handleCertReload()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown cert command: %s\n", args[0])
 		os.Exit(1)
@@ -62,14 +69,12 @@ func handleCertGenerate(force bool) {
 		}
 	}
 
-	// Generate ECDSA P-256 key
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to generate private key: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Create self-signed CA certificate
 	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to generate serial number: %v\n", err)
@@ -96,13 +101,11 @@ func handleCertGenerate(force bool) {
 		os.Exit(1)
 	}
 
-	// Ensure data directory exists
 	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create data directory: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Write certificate
 	certOut, err := os.OpenFile(certFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write certificate: %v\n", err)
@@ -115,7 +118,6 @@ func handleCertGenerate(force bool) {
 	}
 	certOut.Close()
 
-	// Write private key
 	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to marshal private key: %v\n", err)
@@ -288,5 +290,32 @@ func handleCertUninstall() {
 
 	default:
 		fmt.Println("Please remove the Greyproxy CA certificate manually from your OS trust store.")
+	}
+}
+
+// handleCertReload sends a reload request to the running greyproxy instance.
+func handleCertReload() {
+	apiURL := "http://localhost:43080/api/cert/reload"
+	resp, err := http.Post(apiURL, "application/json", bytes.NewReader(nil)) //nolint:gosec,noctx // localhost only, no user input
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to reach greyproxy at %s: %v\n", apiURL, err)
+		fmt.Fprintf(os.Stderr, "Is greyproxy running? Check with: greyproxy service status\n")
+		os.Exit(1)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "reload failed (HTTP %d): %s\n", resp.StatusCode, string(body))
+		os.Exit(1)
+	}
+
+	var result struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &result); err == nil && result.Message != "" {
+		fmt.Println(result.Message)
+	} else {
+		fmt.Println("MITM cert reloaded successfully.")
 	}
 }

--- a/cmd/greyproxy/program.go
+++ b/cmd/greyproxy/program.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
@@ -73,27 +74,7 @@ func (p *program) Start(s service.Service) error {
 	}
 
 	// Auto-inject MITM cert paths if CA files exist
-	certFile := filepath.Join(greyproxyDataHome(), "ca-cert.pem")
-	keyFile := filepath.Join(greyproxyDataHome(), "ca-key.pem")
-	if _, err := os.Stat(certFile); err == nil {
-		if _, err := os.Stat(keyFile); err == nil {
-			for _, svc := range cfg.Services {
-				if svc.Handler == nil {
-					continue
-				}
-				if svc.Handler.Type != "http" && svc.Handler.Type != "socks5" {
-					continue
-				}
-				if svc.Handler.Metadata == nil {
-					svc.Handler.Metadata = make(map[string]any)
-				}
-				if _, ok := svc.Handler.Metadata["mitm.certFile"]; !ok {
-					svc.Handler.Metadata["mitm.certFile"] = certFile
-					svc.Handler.Metadata["mitm.keyFile"] = keyFile
-				}
-			}
-		}
-	}
+	injectCertPaths(cfg, greyproxyDataHome())
 
 	config.Set(cfg)
 
@@ -112,8 +93,83 @@ func (p *program) Start(s service.Service) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 	go p.reload(ctx)
+	go p.watchCertFiles(ctx, greyproxyDataHome())
 
 	return nil
+}
+
+// injectCertPaths injects the CA cert/key paths into HTTP and SOCKS5 handler configs if the files exist.
+func injectCertPaths(cfg *config.Config, dataDir string) {
+	certFile := filepath.Join(dataDir, "ca-cert.pem")
+	keyFile := filepath.Join(dataDir, "ca-key.pem")
+	if _, err := os.Stat(certFile); err != nil {
+		return
+	}
+	if _, err := os.Stat(keyFile); err != nil {
+		return
+	}
+	for _, svc := range cfg.Services {
+		if svc.Handler == nil {
+			continue
+		}
+		if svc.Handler.Type != "http" && svc.Handler.Type != "socks5" {
+			continue
+		}
+		if svc.Handler.Metadata == nil {
+			svc.Handler.Metadata = make(map[string]any)
+		}
+		if _, ok := svc.Handler.Metadata["mitm.certFile"]; !ok {
+			svc.Handler.Metadata["mitm.certFile"] = certFile
+			svc.Handler.Metadata["mitm.keyFile"] = keyFile
+		}
+	}
+}
+
+// watchCertFiles polls ca-cert.pem and ca-key.pem for changes and
+// triggers a config reload (which re-reads the cert files) when they change.
+func (p *program) watchCertFiles(ctx context.Context, dataDir string) {
+	certFile := filepath.Join(dataDir, "ca-cert.pem")
+	keyFile := filepath.Join(dataDir, "ca-key.pem")
+
+	// Record initial modification times
+	mtimes := map[string]time.Time{}
+	for _, f := range []string{certFile, keyFile} {
+		if info, err := os.Stat(f); err == nil {
+			mtimes[f] = info.ModTime()
+		}
+	}
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			changed := false
+			for _, f := range []string{certFile, keyFile} {
+				info, err := os.Stat(f)
+				if err != nil {
+					continue
+				}
+				if !info.ModTime().Equal(mtimes[f]) {
+					mtimes[f] = info.ModTime()
+					changed = true
+				}
+			}
+			if changed {
+				// Brief pause so both cert and key are fully written before reload
+				time.Sleep(500 * time.Millisecond)
+				logger.Default().Info("cert files changed, reloading MITM cert...")
+				if err := p.reloadConfig(); err != nil {
+					logger.Default().Errorf("cert reload failed: %v", err)
+				} else {
+					logger.Default().Info("MITM cert reloaded")
+				}
+			}
+		}
+	}
 }
 
 func (p *program) run(cfg *config.Config) error {
@@ -239,6 +295,7 @@ func (p *program) reloadConfig() error {
 	if err != nil {
 		return err
 	}
+	injectCertPaths(cfg, greyproxyDataHome())
 	config.Set(cfg)
 
 	if err := loader.Load(cfg); err != nil {
@@ -322,20 +379,21 @@ func (p *program) buildGreyproxyService() error {
 		gostx.SetGlobalMitmEnabled(enabled)
 	})
 
+	shared.ReloadCertFn = p.reloadConfig
 	shared.Version = version
 
 	// Collect listening ports for the health endpoint
 	ports := make(map[string]int)
 	if _, portStr, err := net.SplitHostPort(gaCfg.Addr); err == nil {
-		if p, err := strconv.Atoi(portStr); err == nil {
-			ports["api"] = p
+		if portNum, err := strconv.Atoi(portStr); err == nil {
+			ports["api"] = portNum
 		}
 	}
 	for name, svc := range registry.ServiceRegistry().GetAll() {
 		if addr := svc.Addr(); addr != nil {
 			if _, portStr, err := net.SplitHostPort(addr.String()); err == nil {
-				if p, err := strconv.Atoi(portStr); err == nil {
-					ports[name] = p
+				if portNum, err := strconv.Atoi(portStr); err == nil {
+					ports[name] = portNum
 				}
 			}
 		}

--- a/internal/greyproxy/api/cert.go
+++ b/internal/greyproxy/api/cert.go
@@ -129,7 +129,6 @@ func CertGenerateHandler(s *Shared) gin.HandlerFunc {
 			return
 		}
 
-		// Generate ECDSA P-256 key
 		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to generate key: %v", err)})
@@ -162,7 +161,6 @@ func CertGenerateHandler(s *Shared) gin.HandlerFunc {
 			return
 		}
 
-		// Write certificate
 		certOut, err := os.OpenFile(certFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to write cert: %v", err)})
@@ -175,7 +173,6 @@ func CertGenerateHandler(s *Shared) gin.HandlerFunc {
 		}
 		certOut.Close()
 
-		// Write private key
 		keyBytes, err := x509.MarshalECPrivateKey(privateKey)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to marshal key: %v", err)})
@@ -210,5 +207,23 @@ func CertDownloadHandler(s *Shared) gin.HandlerFunc {
 		}
 		c.Header("Content-Disposition", "attachment; filename=greyproxy-ca.pem")
 		c.File(certPath)
+	}
+}
+
+// CertReloadHandler triggers a live reload of the MITM CA certificate.
+func CertReloadHandler(s *Shared) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if s.ReloadCertFn == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "cert reload not available"})
+			return
+		}
+		if err := s.ReloadCertFn(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("reload failed: %v", err)})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message":    "MITM cert reloaded",
+			"certStatus": buildCertStatus(s.DataHome),
+		})
 	}
 }

--- a/internal/greyproxy/api/router.go
+++ b/internal/greyproxy/api/router.go
@@ -20,7 +20,8 @@ type Shared struct {
 	Assembler   *greyproxy.ConversationAssembler
 	Version     string
 	Ports       map[string]int
-	DataHome    string // Path to greyproxy data directory (contains CA cert/key)
+	DataHome    string        // Path to greyproxy data directory (contains CA cert/key)
+	ReloadCertFn func() error // Triggers a live MITM cert reload (set by the running service)
 }
 
 // NewRouter creates the Gin router with all routes.
@@ -89,6 +90,7 @@ func NewRouter(s *Shared, pathPrefix string) (*gin.Engine, *gin.RouterGroup) {
 		api.GET("/cert/status", CertStatusHandler(s))
 		api.POST("/cert/generate", CertGenerateHandler(s))
 		api.GET("/cert/download", CertDownloadHandler(s))
+		api.POST("/cert/reload", CertReloadHandler(s))
 
 		// Maintenance
 		api.POST("/maintenance/rebuild-conversations", RebuildConversationsHandler(s))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/release.sh [patch|minor|beta]
+# Default: patch
+
+BUMP_TYPE="${1:-patch}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# Validate bump type
+if [[ "$BUMP_TYPE" != "patch" && "$BUMP_TYPE" != "minor" && "$BUMP_TYPE" != "beta" ]]; then
+    error "Invalid bump type: $BUMP_TYPE. Use 'patch', 'minor', or 'beta'."
+fi
+
+info "Bump type: $BUMP_TYPE"
+
+# =============================================================================
+# Preflight checks
+# =============================================================================
+
+info "Running preflight checks..."
+
+# Check we're in a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    error "Not in a git repository"
+fi
+
+# Check we're on the default branch (main)
+DEFAULT_BRANCH="main"
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
+    error "Not on default branch. Current: $CURRENT_BRANCH, Expected: $DEFAULT_BRANCH"
+fi
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --staged --quiet; then
+    error "Working directory has uncommitted changes. Commit or stash them first."
+fi
+
+# Check for untracked files (warning only)
+UNTRACKED=$(git ls-files --others --exclude-standard)
+if [[ -n "$UNTRACKED" ]]; then
+    warn "Untracked files present (continuing anyway):"
+    echo "$UNTRACKED" | head -5
+fi
+
+# Fetch latest from remote
+info "Fetching latest from origin..."
+git fetch origin "$DEFAULT_BRANCH" --tags
+
+# Check if local branch is up to date with remote
+LOCAL_COMMIT=$(git rev-parse HEAD)
+REMOTE_COMMIT=$(git rev-parse "origin/$DEFAULT_BRANCH")
+if [[ "$LOCAL_COMMIT" != "$REMOTE_COMMIT" ]]; then
+    error "Local branch is not up to date with origin/$DEFAULT_BRANCH. Run 'git pull' first."
+fi
+
+# Check if there are commits since last tag
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -n "$LAST_TAG" ]]; then
+    COMMITS_SINCE_TAG=$(git rev-list "$LAST_TAG"..HEAD --count)
+    if [[ "$COMMITS_SINCE_TAG" -eq 0 ]]; then
+        error "No commits since last tag ($LAST_TAG). Nothing to release."
+    fi
+    info "Commits since $LAST_TAG: $COMMITS_SINCE_TAG"
+fi
+
+info "✓ All preflight checks passed"
+
+# =============================================================================
+# Calculate new version
+# =============================================================================
+
+if [[ -z "$LAST_TAG" ]]; then
+    # No existing tags, start at v0.1.0
+    NEW_VERSION="v0.1.0"
+    if [[ "$BUMP_TYPE" == "beta" ]]; then
+        NEW_VERSION="v0.1.0-beta.1"
+    fi
+    info "No existing tags found. Starting at $NEW_VERSION"
+else
+    if [[ "$BUMP_TYPE" == "beta" ]]; then
+        # Find the last stable tag (ignore -beta.* tags) as the base
+        LAST_STABLE_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -v '\-' | sort -V | tail -1 || true)
+        if [[ -z "$LAST_STABLE_TAG" ]]; then
+            LAST_STABLE_TAG="v0.0.0"
+        fi
+        VERSION="${LAST_STABLE_TAG#v}"
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+        PATCH=$((PATCH + 1))
+        BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+        # Find highest existing beta number for this base version
+        LATEST_BETA=$(git tag -l "v${BASE_VERSION}-beta.*" | sort -V | tail -1 || true)
+        if [[ -z "$LATEST_BETA" ]]; then
+            BETA_NUM=1
+        else
+            BETA_NUM=$(echo "$LATEST_BETA" | sed 's/.*-beta\.\([0-9]*\)$/\1/')
+            BETA_NUM=$((BETA_NUM + 1))
+        fi
+        NEW_VERSION="v${BASE_VERSION}-beta.${BETA_NUM}"
+        info "Beta tag: $LAST_STABLE_TAG → $NEW_VERSION"
+    else
+        # Parse current version (strip 'v' prefix and any pre-release suffix)
+        VERSION="${LAST_TAG#v}"
+        VERSION="${VERSION%%-*}"  # strip pre-release suffix if present
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+        # Validate parsed version
+        if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
+            error "Failed to parse version from tag: $LAST_TAG"
+        fi
+
+        # Increment based on bump type
+        case "$BUMP_TYPE" in
+            patch)
+                PATCH=$((PATCH + 1))
+                ;;
+            minor)
+                MINOR=$((MINOR + 1))
+                PATCH=0
+                ;;
+        esac
+
+        NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+        info "Version bump: $LAST_TAG → $NEW_VERSION"
+    fi
+fi
+
+# =============================================================================
+# Confirm and create tag
+# =============================================================================
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Ready to release: $NEW_VERSION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+read -p "Create and push tag $NEW_VERSION? [y/N] " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    info "Aborted."
+    exit 0
+fi
+
+# Create annotated tag
+info "Creating tag $NEW_VERSION..."
+git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+
+# Push tag to origin
+info "Pushing tag to origin..."
+git push origin "$NEW_VERSION"
+
+echo ""
+info "✓ Released $NEW_VERSION"
+info "GitHub Actions will now build and publish the release."
+info "Watch progress at: https://github.com/GreyhavenHQ/greyproxy/actions"


### PR DESCRIPTION
**feat: beta channel and live MITM cert reload**

**Beta channel**
* Created `scripts/release.sh` with `patch`, `minor`, and `beta` bump types (same logic as greywall)
* Added `make release`, `make release-minor`, `make release-beta` targets
* Added `skip_upload: auto` to `.goreleaser.yaml` so beta tags skip the Homebrew tap

**Certificate reload (no restart needed)**
* Extracted `injectCertPaths` helper — injects `mitm.certFile`/`mitm.keyFile` into HTTP and SOCKS5 handler configs if cert files exist; now called from both `Start` and `reloadConfig` (previously SIGHUP reloads were missing the cert injection)
* Added `watchCertFiles` goroutine: polls `ca-cert.pem` and `ca-key.pem` every 5 seconds, triggers `reloadConfig` on mtime change with 500ms debounce to let both files finish writing
* Added `POST /api/cert/reload` endpoint (`CertReloadHandler`) wired to `p.reloadConfig` via `ReloadCertFn` on `Shared`
* Added `greyproxy cert reload` CLI subcommand — hits the endpoint and prints the result