### PR TITLE
fix: terminal-notifier homebrew path

### DIFF
--- a/internal/greyproxy/notifier.go
+++ b/internal/greyproxy/notifier.go
@@ -58,7 +58,7 @@ type notifyBackend int
 const (
 	backendNone notifyBackend = iota
 	backendNotifySend
-	backendOsascript
+	backendTerminalNotifier
 )
 
 // notifySendCaps tracks which features the installed notify-send supports.
@@ -101,9 +101,29 @@ func detectBackend() notifyBackend {
 			return backendNotifySend
 		}
 	case "darwin":
-		return backendOsascript
+		if findTerminalNotifier() != "" {
+			return backendTerminalNotifier
+		}
 	}
 	return backendNone
+}
+
+// findTerminalNotifier returns the path to terminal-notifier, checking both
+// PATH and common Homebrew install locations (launchd agents run with a
+// minimal PATH that excludes /opt/homebrew/bin and /usr/local/bin).
+func findTerminalNotifier() string {
+	if p, err := exec.LookPath("terminal-notifier"); err == nil {
+		return p
+	}
+	for _, candidate := range []string{
+		"/opt/homebrew/bin/terminal-notifier", // Apple Silicon Homebrew
+		"/usr/local/bin/terminal-notifier",    // Intel Homebrew
+	} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // BackendInfo returns information about the notification backend,
@@ -116,7 +136,8 @@ func (n *Notifier) BackendInfo() NotificationBackendInfo {
 	if !info.Available {
 		info.InstallHint = installHint()
 	}
-	info.SupportsActions = n.backend == backendOsascript || n.linuxCaps.actions
+	// terminal-notifier on macOS always supports actions.
+	info.SupportsActions = n.backend == backendTerminalNotifier || n.linuxCaps.actions
 	return info
 }
 
@@ -158,7 +179,10 @@ func parseVersion(v string) (major, minor int) {
 }
 
 func installHint() string {
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "darwin":
+		return "Install terminal-notifier with: brew install terminal-notifier"
+	case "linux":
 		return "Install libnotify with: sudo apt install libnotify-bin (Debian/Ubuntu) or sudo dnf install libnotify-utils (Fedora)"
 	}
 	return "Desktop notifications are not supported on this platform."
@@ -212,15 +236,15 @@ func (n *Notifier) Start() {
 	if n.backend == backendNotifySend && !n.linuxCaps.actions {
 		n.log.Warn("notify-send < 0.8 detected; running in basic mode (no click actions or auto-dismiss)")
 	}
-	n.log.Infof("notifier started (enabled=%v, backend=%v, actions=%v)", n.enabled.Load(), n.backendName(), n.linuxCaps.actions || n.backend == backendOsascript)
+	n.log.Infof("notifier started (enabled=%v, backend=%v, actions=%v)", n.enabled.Load(), n.backendName(), n.linuxCaps.actions || n.backend == backendTerminalNotifier)
 }
 
 func (n *Notifier) backendName() string {
 	switch n.backend {
 	case backendNotifySend:
 		return "notify-send"
-	case backendOsascript:
-		return "osascript"
+	case backendTerminalNotifier:
+		return "terminal-notifier"
 	default:
 		return "none"
 	}
@@ -404,8 +428,8 @@ func (n *Notifier) sendNotification(title, body, url string, pendingID int64) {
 	switch n.backend {
 	case backendNotifySend:
 		n.sendLinux(title, body, url, pendingID)
-	case backendOsascript:
-		n.sendDarwinOsascript(title, body, pendingID)
+	case backendTerminalNotifier:
+		n.sendDarwinTerminalNotifier(title, body, url, pendingID)
 	}
 }
 
@@ -479,46 +503,28 @@ func (n *Notifier) sendLinuxBasic(title, body string, pendingID int64) {
 	}()
 }
 
-// sendDarwinOsascript shows a modal Allow/Deny dialog using osascript.
-// osascript is always available on macOS and supports action buttons natively.
-func (n *Notifier) sendDarwinOsascript(title, body string, pendingID int64) {
+func (n *Notifier) sendDarwinTerminalNotifier(title, body, url string, pendingID int64) {
+	bin := findTerminalNotifier()
+	if bin == "" {
+		return
+	}
 	go func() {
-		script := fmt.Sprintf(
-			`display dialog %q buttons {"Deny", "Allow"} default button "Allow" with title %q giving up after 30`,
-			body, title,
+		cmd := exec.Command(bin, //nolint:gosec // path resolved from known locations
+			"-title", title,
+			"-message", body,
+			"-open", url,
+			"-group", fmt.Sprintf("greyproxy-%d", pendingID),
+			"-sender", "com.apple.Safari",
+			"-timeout", "30",
 		)
-		out, err := exec.Command("osascript", "-e", script).Output() //nolint:gosec
-		if err != nil {
-			// User cancelled (Esc / Cmd-.) or osascript error — no action.
-			n.log.Debugf("osascript dialog for pending %d: %v", pendingID, err)
+
+		if err := cmd.Start(); err != nil {
+			n.log.Debugf("terminal-notifier start: %v", err)
 			return
 		}
 
-		result := strings.TrimSpace(string(out))
-		if strings.Contains(result, "gave up:true") {
-			return
-		}
-		switch {
-		case strings.Contains(result, "button returned:Allow"):
-			rule, err := AllowPending(n.db, pendingID, "exact", "permanent", nil)
-			if err != nil {
-				n.log.Warnf("allow pending %d from dialog: %v", pendingID, err)
-			} else {
-				n.bus.Publish(Event{
-					Type: EventPendingAllowed,
-					Data: map[string]any{"pending_id": pendingID, "rule": rule.ToJSON()},
-				})
-			}
-		case strings.Contains(result, "button returned:Deny"):
-			rule, err := DenyPending(n.db, pendingID, "exact", "permanent", nil)
-			if err != nil {
-				n.log.Warnf("deny pending %d from dialog: %v", pendingID, err)
-			} else {
-				n.bus.Publish(Event{
-					Type: EventPendingDismissed,
-					Data: map[string]any{"pending_id": pendingID, "rule": rule.ToJSON()},
-				})
-			}
-		}
+		n.trackNotification(pendingID, cmd.Process)
+		cmd.Wait()
+		n.untrackNotification(pendingID)
 	}()
 }


### PR DESCRIPTION
## Summary
* greyproxy runs as a launchd service with a minimal PATH that excludes `/opt/homebrew/bin` and `/usr/local/bin`, so `terminal-notifier` was never found even when installed — resulting in no notifications being shown.
* Fixed by resolving `terminal-notifier` from known Homebrew install paths as a fallback when it isn't on PATH.

## Changes
* Added `findTerminalNotifier()` which checks PATH first, then falls back to `/opt/homebrew/bin/terminal-notifier` (Apple Silicon) and `/usr/local/bin/terminal-notifier` (Intel)
* `detectBackend` and `sendDarwinTerminalNotifier` now use `findTerminalNotifier()` instead of relying solely on `exec.LookPath`

<img width="1287" height="907" alt="trq" src="https://github.com/user-attachments/assets/557451c2-4014-4d69-82aa-6d324428c7c2" />


## Test plan
*  Install `terminal-notifier` via Homebrew
*  Run greyproxy as a launchd service (not from a terminal)
*  Trigger a blocked connection via greywall
*  Confirm notification appears

Closes GreyhavenHQ/greywall#27