### PR TITLE
feat: add copy button for global credential placeholder values

### DIFF
--- a/internal/greyproxy/ui/templates/settings.html
+++ b/internal/greyproxy/ui/templates/settings.html
@@ -276,7 +276,7 @@
         <div id="cred-usage-details" class="hidden p-3 mb-4 rounded-md bg-muted border border-border space-y-2">
             <p class="text-xs font-medium text-foreground">Usage</p>
             <code class="text-xs font-mono text-muted-foreground block">greywall --inject ANTHROPIC_API_KEY -- your-command</code>
-            <p class="text-xs text-muted-foreground">Use <code class="font-mono">--inject</code> multiple times to inject several credentials. Greywall sets the placeholder as an environment variable <em>and</em> rewrites <code class="font-mono">.env</code> / <code class="font-mono">.env.local</code> files so the real value never reaches the sandbox, regardless of where the application reads it from.</p>
+            <p class="text-xs text-muted-foreground">Use <code class="font-mono">--inject</code> multiple times to inject several credentials. Greywall sets the placeholder as an environment variable <em>and</em> rewrites <code class="font-mono">.env</code> / <code class="font-mono">.env.local</code> files so the real value never reaches the sandbox, regardless of where the application reads it from. <span class="text-muted-foreground/70">(Note: <code class="font-mono">.env</code> rewriting is currently Linux only.)</span></p>
             <p class="text-xs text-muted-foreground">Once active, the proxy replaces <strong>every occurrence</strong> of the placeholder in HTTP headers and query parameters with the real credential value before forwarding upstream.</p>
         </div>
 


### PR DESCRIPTION
## Summary
  - Adds a Copy button next to each global credential in Settings > Credentials
  - Copies the placeholder value to clipboard for manual env var setup without --inject
  - Shows Copied! feedback for 1.5s, consistent with existing UI patterns

  Closes #27

  ## Test plan
  - [x] Create a global credential in the dashboard
  - [x] Click Copy and verify the placeholder value is in clipboard
  - [x] Verify Copied! feedback appears and reverts
  - [x] Verify Delete button still works