### PR TITLE
fix: persist DNS cache to SQLite to survive restarts

### DIFF
--- a/internal/greyproxy/crud_test.go
+++ b/internal/greyproxy/crud_test.go
@@ -637,8 +637,8 @@ func TestMigrations(t *testing.T) {
 	// Verify migration versions were recorded
 	var count int
 	db.ReadDB().QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
-	if count != 9 {
-		t.Errorf("expected 9 migration versions, got %d", count)
+	if count != 10 {
+		t.Errorf("expected 10 migration versions, got %d", count)
 	}
 }
 

--- a/internal/greyproxy/dns_cache.go
+++ b/internal/greyproxy/dns_cache.go
@@ -9,30 +9,87 @@ import (
 
 const defaultDNSCacheTTL = 1 * time.Hour
 
+// dnsCacheDBTTL is how long DB entries are considered valid (7 days).
+const dnsCacheDBTTL = 7 * 24 * time.Hour
+
 type dnsCacheEntry struct {
 	hostname string
 	expiry   time.Time
 }
 
 // DNSCache provides a thread-safe IP-to-hostname cache with TTL.
+// When a DB is attached, entries are persisted to SQLite and restored on startup.
 type DNSCache struct {
 	mu      sync.RWMutex
 	entries map[string]dnsCacheEntry // IP -> hostname
 	ttl     time.Duration
+	db      *DB
 }
 
-func NewDNSCache() *DNSCache {
-	return &DNSCache{
+func NewDNSCache(db *DB) *DNSCache {
+	c := &DNSCache{
 		entries: make(map[string]dnsCacheEntry),
 		ttl:     defaultDNSCacheTTL,
+		db:      db,
+	}
+	if db != nil {
+		c.loadFromDB()
+	}
+	return c
+}
+
+// loadFromDB hydrates the in-memory cache from persisted entries.
+func (c *DNSCache) loadFromDB() {
+	cutoff := time.Now().Add(-dnsCacheDBTTL)
+	rows, err := c.db.ReadDB().Query(
+		"SELECT ip, hostname FROM dns_cache WHERE updated_at > ?",
+		cutoff.UTC().Format("2006-01-02 15:04:05"),
+	)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for rows.Next() {
+		var ip, hostname string
+		if err := rows.Scan(&ip, &hostname); err != nil {
+			continue
+		}
+		c.entries[ip] = dnsCacheEntry{hostname: hostname, expiry: time.Now().Add(c.ttl)}
 	}
 }
 
+// persistToDB writes an IP-to-hostname mapping to the database.
+func (c *DNSCache) persistToDB(ip, hostname string) {
+	if c.db == nil {
+		return
+	}
+	go func() {
+		c.db.Lock()
+		defer c.db.Unlock()
+		c.db.WriteDB().Exec(
+			"INSERT OR REPLACE INTO dns_cache (ip, hostname, updated_at) VALUES (?, ?, datetime('now'))",
+			ip, hostname,
+		)
+	}()
+}
+
 // ResolveIP attempts to get a hostname for the given IP.
-// Checks cache first, then falls back to reverse DNS lookup.
+// Checks in-memory cache first, then DB, then falls back to reverse DNS lookup.
 func (c *DNSCache) ResolveIP(ip string) string {
-	// Check cache
+	// Check in-memory cache
 	if hostname := c.GetCached(ip); hostname != "" {
+		return hostname
+	}
+
+	// Check DB before reverse DNS
+	if hostname := c.getFromDB(ip); hostname != "" {
+		c.mu.Lock()
+		c.entries[ip] = dnsCacheEntry{hostname: hostname, expiry: time.Now().Add(c.ttl)}
+		c.mu.Unlock()
 		return hostname
 	}
 
@@ -52,6 +109,25 @@ func (c *DNSCache) ResolveIP(ip string) string {
 	c.entries[ip] = dnsCacheEntry{hostname: hostname, expiry: time.Now().Add(c.ttl)}
 	c.mu.Unlock()
 
+	c.persistToDB(ip, hostname)
+
+	return hostname
+}
+
+// getFromDB looks up a hostname from the persistent cache.
+func (c *DNSCache) getFromDB(ip string) string {
+	if c.db == nil {
+		return ""
+	}
+	cutoff := time.Now().Add(-dnsCacheDBTTL)
+	var hostname string
+	err := c.db.ReadDB().QueryRow(
+		"SELECT hostname FROM dns_cache WHERE ip = ? AND updated_at > ?",
+		ip, cutoff.UTC().Format("2006-01-02 15:04:05"),
+	)
+	if err := err.Scan(&hostname); err != nil {
+		return ""
+	}
 	return hostname
 }
 
@@ -72,6 +148,20 @@ func (c *DNSCache) RegisterIPs(hostname string, ips []string) {
 	expiry := time.Now().Add(c.ttl)
 	for _, ip := range ips {
 		c.entries[ip] = dnsCacheEntry{hostname: hostname, expiry: expiry}
+	}
+
+	// Persist to DB
+	if c.db != nil {
+		go func() {
+			c.db.Lock()
+			defer c.db.Unlock()
+			for _, ip := range ips {
+				c.db.WriteDB().Exec(
+					"INSERT OR REPLACE INTO dns_cache (ip, hostname, updated_at) VALUES (?, ?, datetime('now'))",
+					ip, hostname,
+				)
+			}
+		}()
 	}
 }
 

--- a/internal/greyproxy/dns_cache_test.go
+++ b/internal/greyproxy/dns_cache_test.go
@@ -1,12 +1,15 @@
 package greyproxy
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestDNSCacheRegisterAndGet(t *testing.T) {
-	cache := NewDNSCache()
+	cache := NewDNSCache(nil)
 
 	cache.RegisterIPs("example.com", []string{"1.2.3.4", "5.6.7.8"})
 
@@ -43,7 +46,7 @@ func TestDNSCacheExpiry(t *testing.T) {
 }
 
 func TestDNSCacheResolveIPUsesCache(t *testing.T) {
-	cache := NewDNSCache()
+	cache := NewDNSCache(nil)
 
 	// Pre-populate cache
 	cache.RegisterIPs("example.com", []string{"1.2.3.4"})
@@ -52,5 +55,136 @@ func TestDNSCacheResolveIPUsesCache(t *testing.T) {
 	got := cache.ResolveIP("1.2.3.4")
 	if got != "example.com" {
 		t.Errorf("expected cached result, got %q", got)
+	}
+}
+
+func setupDNSTestDB(t *testing.T) *DB {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "greyproxy_dns_test_*.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	db, err := OpenDB(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := db.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestDNSCacheDBPersistAndReload(t *testing.T) {
+	db := setupDNSTestDB(t)
+
+	// Create a cache with DB and register entries
+	cache1 := NewDNSCache(db)
+	cache1.RegisterIPs("example.com", []string{"10.0.0.1", "10.0.0.2"})
+
+	// Let async DB writes complete
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify entries are in the database
+	var count int
+	db.ReadDB().QueryRow("SELECT COUNT(*) FROM dns_cache").Scan(&count)
+	if count != 2 {
+		t.Fatalf("expected 2 rows in dns_cache, got %d", count)
+	}
+
+	// Create a new cache from the same DB (simulates restart)
+	cache2 := NewDNSCache(db)
+
+	// Should have the entries loaded from DB
+	if got := cache2.GetCached("10.0.0.1"); got != "example.com" {
+		t.Errorf("after reload: got %q, want %q", got, "example.com")
+	}
+	if got := cache2.GetCached("10.0.0.2"); got != "example.com" {
+		t.Errorf("after reload: got %q, want %q", got, "example.com")
+	}
+}
+
+func TestDNSCacheDBFallbackOnMemoryExpiry(t *testing.T) {
+	db := setupDNSTestDB(t)
+
+	// Create a cache with very short in-memory TTL but DB backing
+	cache := &DNSCache{
+		entries: make(map[string]dnsCacheEntry),
+		ttl:     1 * time.Millisecond,
+		db:      db,
+	}
+	cache.RegisterIPs("example.com", []string{"10.0.0.1"})
+
+	// Let async DB write complete
+	time.Sleep(50 * time.Millisecond)
+
+	// In-memory entry should be expired
+	if got := cache.GetCached("10.0.0.1"); got != "" {
+		t.Errorf("expected in-memory entry to be expired, got %q", got)
+	}
+
+	// ResolveIP should fall back to DB and recover the hostname
+	got := cache.ResolveIP("10.0.0.1")
+	if got != "example.com" {
+		t.Errorf("expected DB fallback to return %q, got %q", "example.com", got)
+	}
+
+	// After DB fallback, should be back in memory
+	if got := cache.GetCached("10.0.0.1"); got != "example.com" {
+		t.Errorf("expected re-cached value %q, got %q", "example.com", got)
+	}
+}
+
+func TestDNSCacheDBExpiredEntriesNotLoaded(t *testing.T) {
+	db := setupDNSTestDB(t)
+
+	// Insert an entry with an old updated_at (beyond 7-day TTL)
+	db.Lock()
+	db.WriteDB().Exec(
+		"INSERT INTO dns_cache (ip, hostname, updated_at) VALUES (?, ?, datetime('now', '-8 days'))",
+		"10.0.0.1", "stale.example.com",
+	)
+	db.Unlock()
+
+	// New cache should NOT load the stale entry
+	cache := NewDNSCache(db)
+	if got := cache.GetCached("10.0.0.1"); got != "" {
+		t.Errorf("expected stale entry to not be loaded, got %q", got)
+	}
+
+	// getFromDB should also not return it
+	if got := cache.getFromDB("10.0.0.1"); got != "" {
+		t.Errorf("expected stale entry to not be returned from DB, got %q", got)
+	}
+}
+
+func TestDNSCacheDBUpsertUpdatesTimestamp(t *testing.T) {
+	db := setupDNSTestDB(t)
+
+	cache := NewDNSCache(db)
+
+	// Register, then re-register with different hostname
+	cache.RegisterIPs("old.example.com", []string{"10.0.0.1"})
+	time.Sleep(50 * time.Millisecond)
+
+	cache.RegisterIPs("new.example.com", []string{"10.0.0.1"})
+	time.Sleep(50 * time.Millisecond)
+
+	// DB should have the latest hostname
+	var hostname string
+	db.ReadDB().QueryRow("SELECT hostname FROM dns_cache WHERE ip = ?", "10.0.0.1").Scan(&hostname)
+	if hostname != "new.example.com" {
+		t.Errorf("expected upserted hostname %q, got %q", "new.example.com", hostname)
+	}
+
+	// Only one row for that IP
+	var count int
+	db.ReadDB().QueryRow("SELECT COUNT(*) FROM dns_cache WHERE ip = ?", "10.0.0.1").Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 row for IP, got %d", count)
 	}
 }

--- a/internal/greyproxy/greyproxy.go
+++ b/internal/greyproxy/greyproxy.go
@@ -86,7 +86,7 @@ func NewService(cfg *Config, handler http.Handler) (*Service, error) {
 		},
 		addr:    addr,
 		DB:      db,
-		Cache:   NewDNSCache(),
+		Cache:   NewDNSCache(db),
 		Bus:     bus,
 		Waiters: NewWaiterTracker(bus),
 	}, nil

--- a/internal/greyproxy/migrations.go
+++ b/internal/greyproxy/migrations.go
@@ -169,6 +169,13 @@ var migrations = []string{
 	ALTER TABLE http_transactions ADD COLUMN session_id TEXT DEFAULT NULL;
 	CREATE INDEX IF NOT EXISTS idx_http_transactions_session ON http_transactions(session_id);
 	ALTER TABLE sessions ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}';`,
+
+	// Migration 10: Create dns_cache table for persistent IP-to-hostname mappings
+	`CREATE TABLE IF NOT EXISTS dns_cache (
+		ip TEXT PRIMARY KEY,
+		hostname TEXT NOT NULL,
+		updated_at DATETIME NOT NULL DEFAULT (datetime('now'))
+	);`,
 }
 
 func runMigrations(db *sql.DB) error {


### PR DESCRIPTION
## Summary
- Add SQLite-backed persistence layer to `DNSCache` so IP-to-hostname mappings survive restarts
- New `dns_cache` table (migration 10) with write-through on every registration
- On startup, hydrate in-memory cache from DB entries younger than 7 days
- On in-memory cache miss, fall back to DB lookup before reverse DNS

## Test plan
- [x] Existing in-memory cache tests pass unchanged
- [x] `TestDNSCacheDBPersistAndReload` - entries survive simulated restart
- [x] `TestDNSCacheDBFallbackOnMemoryExpiry` - DB fallback when in-memory TTL expires
- [x] `TestDNSCacheDBExpiredEntriesNotLoaded` - entries older than 7 days are ignored
- [x] `TestDNSCacheDBUpsertUpdatesTimestamp` - re-registration updates hostname, no duplicates

Closes #20