### PR TITLE
fix: auto-generate and trust CA cert during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This software is meant to be used with [**greywall**](https://github.com/Greyhav
 ```bash
 brew tap greyhavenhq/tap
 brew install greyproxy
+greyproxy install
 ```
 
 ### Build from Source
@@ -43,52 +44,49 @@ brew install greyproxy
 git clone https://github.com/greyhavenhq/greyproxy.git
 cd greyproxy
 go build ./cmd/greyproxy
+./greyproxy install
 ```
 
-**macOS only:** after building, codesign the binary to avoid Gatekeeper quarantine:
+**macOS only:** after building, codesign the binary before installing to avoid Gatekeeper quarantine:
 
 ```bash
 codesign --sign - --force ./greyproxy
 ```
 
-Install the binary and register it as a service:
-
-```bash
-./greyproxy install
-```
-
-This copies the binary to `~/.local/bin/`, registers a launchd user agent (macOS) or systemd user service (Linux), and starts it automatically. The dashboard will be available at `http://localhost:43080`.
-
-Generate and install the CA certificate for HTTPS inspection:
-
-```bash
-greyproxy cert generate
-greyproxy cert install
-```
-
-`greyproxy install` generates the certificate automatically on first install if one does not exist. If you regenerate the certificate later, greyproxy detects the change and reloads automatically — no restart needed. You can also trigger a reload manually:
-
-```bash
-greyproxy cert reload
-```
-
 Alternatively, use [`greywall setup`](https://github.com/GreyhavenHQ/greywall) to handle the full build and install automatically.
 
-### Install
+### What `install` Does
 
-Install the binary to `~/.local/bin/` and register it as a systemd user service:
+`greyproxy install` handles the full setup in one step:
 
-```bash
-./greyproxy install
-```
+1. Copies the binary to `~/.local/bin/` (skipped for Homebrew installs)
+2. Registers a launchd user agent (macOS) or systemd user service (Linux)
+3. Generates a CA certificate for HTTPS inspection (if not already present)
+4. Installs the CA certificate into the OS trust store (requires sudo)
+5. Starts the service
 
-This copies the binary, registers a systemd user service, and starts it automatically. The dashboard will be available at `http://localhost:43080`.
+The dashboard will be available at `http://localhost:43080`.
+
+If you decline the sudo prompt for certificate trust, HTTPS inspection will not work until you run `greyproxy cert install` manually.
 
 To remove everything:
 
 ```bash
 greyproxy uninstall
 ```
+
+### Certificate Management
+
+The CA certificate is generated and trusted automatically during `greyproxy install`. For manual control:
+
+```bash
+greyproxy cert generate    # regenerate the CA certificate
+greyproxy cert install     # trust it on the OS (requires sudo)
+greyproxy cert uninstall   # remove from OS trust store
+greyproxy cert reload      # reload cert in running server (no restart needed)
+```
+
+If you regenerate the certificate, greyproxy detects the file change and reloads it automatically.
 
 ### Run in Foreground
 

--- a/cmd/greyproxy/install.go
+++ b/cmd/greyproxy/install.go
@@ -106,11 +106,18 @@ func handleInstall(args []string) {
 	}
 
 	label := serviceLabel()
+	step := 3
 	fmt.Printf("Ready to install greyproxy. This will:\n")
 	fmt.Printf("  1. Copy %s -> %s\n", binSrc, binDst)
 	fmt.Printf("  2. Register greyproxy as a %s\n", label)
-	fmt.Printf("  3. Generate CA certificate (if not already present)\n")
-	fmt.Printf("  4. Start the service\n")
+	if _, err := os.Stat(filepath.Join(greyproxyDataHome(), "ca-cert.pem")); os.IsNotExist(err) {
+		fmt.Printf("  %d. Generate and trust CA certificate (requires sudo)\n", step)
+		step++
+	} else if !isCertInstalled() {
+		fmt.Printf("  %d. Install CA certificate into OS trust store (requires sudo)\n", step)
+		step++
+	}
+	fmt.Printf("  %d. Start the service\n", step)
 
 	if !force {
 		fmt.Printf("\nProceed? [Y/n] ")
@@ -157,6 +164,9 @@ func handleBrewInstall(brewBin string, force bool) {
 		os.Exit(1)
 	}
 	fmt.Printf("Registered %s\n", label)
+
+	// Generate and trust CA certificate
+	ensureCert()
 
 	if err := service.Control(s, "start"); err != nil {
 		fmt.Fprintf(os.Stderr, "error: starting service: %v\n", err)
@@ -227,11 +237,8 @@ func freshInstall(binSrc, binDst string) {
 	}
 	fmt.Printf("Registered %s\n", label)
 
-	// Generate CA certificate if not already present
-	certFile := filepath.Join(greyproxyDataHome(), "ca-cert.pem")
-	if _, err := os.Stat(certFile); os.IsNotExist(err) {
-		handleCertGenerate(false)
-	}
+	// Generate and trust CA certificate
+	ensureCert()
 
 	// Start service
 	if err := service.Control(s, "start"); err != nil {
@@ -239,6 +246,80 @@ func freshInstall(binSrc, binDst string) {
 		os.Exit(1)
 	}
 	fmt.Println("Service started")
+}
+
+// ensureCert generates the CA certificate if missing and attempts to install
+// it into the OS trust store. If the trust step fails (e.g. sudo unavailable
+// in a non-interactive context), installation continues but the user is told
+// to run 'greyproxy cert install' manually.
+func ensureCert() {
+	certFile := filepath.Join(greyproxyDataHome(), "ca-cert.pem")
+	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+		handleCertGenerate(false)
+	}
+
+	if isCertInstalled() {
+		return
+	}
+
+	if !tryCertInstall() {
+		fmt.Println("\n  HTTPS inspection requires a trusted CA certificate.")
+		fmt.Println("  Run 'greyproxy cert install' to complete the setup.")
+	}
+}
+
+// tryCertInstall attempts to install the CA certificate into the OS trust
+// store. Returns true on success, false if the install failed (e.g. sudo
+// not available or user denied the prompt).
+func tryCertInstall() bool {
+	certFile := filepath.Join(greyproxyDataHome(), "ca-cert.pem")
+	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+		return false
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		// Remove any existing Greyproxy CA cert to avoid errSecDuplicateItem
+		exec.Command("security", "delete-certificate", "-c", "Greyproxy CA").Run()
+
+		fmt.Println("Installing CA certificate into system trust store (requires sudo)...")
+		cmd := exec.Command("sudo", "security", "add-trusted-cert",
+			"-d", "-p", "ssl", "-p", "basic",
+			"-k", "/Library/Keychains/System.keychain",
+			certFile,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Run(); err != nil {
+			return false
+		}
+		fmt.Println("CA certificate installed and trusted")
+		return true
+
+	case "linux":
+		destPath, updateCmd := linuxCertInstallInfo()
+		fmt.Println("Installing CA certificate into system trust store (requires sudo)...")
+		cpCmd := exec.Command("sudo", "cp", certFile, destPath)
+		cpCmd.Stdout = os.Stdout
+		cpCmd.Stderr = os.Stderr
+		cpCmd.Stdin = os.Stdin
+		if err := cpCmd.Run(); err != nil {
+			return false
+		}
+		updCmd := exec.Command("sudo", updateCmd)
+		updCmd.Stdout = os.Stdout
+		updCmd.Stderr = os.Stderr
+		updCmd.Stdin = os.Stdin
+		if err := updCmd.Run(); err != nil {
+			return false
+		}
+		fmt.Printf("CA certificate installed and trusted at %s\n", destPath)
+		return true
+
+	default:
+		return false
+	}
 }
 
 func askConfirm() bool {

--- a/internal/greyproxy/api/cert.go
+++ b/internal/greyproxy/api/cert.go
@@ -66,14 +66,13 @@ func buildCertStatus(dataHome string) certStatusResponse {
 	return resp
 }
 
-func buildInstallCommands(certPath string) map[string]string {
+func buildInstallCommands(_ string) map[string]string {
 	cmds := make(map[string]string)
 	switch runtime.GOOS {
 	case "darwin":
-		cmds["macos"] = fmt.Sprintf("sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain \"%s\"", certPath)
+		cmds["macos"] = "greyproxy cert install"
 	case "linux":
-		destPath, updateCmd := linuxCertInstallInfo()
-		cmds["linux"] = fmt.Sprintf("sudo cp \"%s\" %s && sudo %s", certPath, destPath, updateCmd)
+		cmds["linux"] = "greyproxy cert install"
 	}
 	return cmds
 }

--- a/internal/greyproxy/ui/templates/settings.html
+++ b/internal/greyproxy/ui/templates/settings.html
@@ -217,7 +217,7 @@
                 <div id="cert-install-section" class="hidden mb-4">
                     <div class="p-4 bg-muted rounded-lg border border-border">
                         <p class="font-medium text-sm mb-2">Install in system trust store</p>
-                        <p class="text-xs text-muted-foreground mb-3">Run this command in your terminal to trust the CA certificate system-wide:</p>
+                        <p class="text-xs text-muted-foreground mb-3">Run this in your terminal to trust the CA certificate system-wide (requires sudo):</p>
                         <div class="relative">
                             <pre id="cert-install-cmd" class="text-xs bg-background rounded p-3 pr-10 overflow-x-auto border border-border font-mono"></pre>
                             <button onclick="copyInstallCmd()" class="absolute top-2 right-2 p-1 rounded hover:bg-muted-foreground/10" title="Copy to clipboard">
@@ -663,7 +663,7 @@
             document.getElementById('cert-install-section').classList.add('hidden');
         } else {
             icon.innerHTML = '<svg class="h-5 w-5 text-yellow-600 dark:text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" /></svg>';
-            text.innerHTML = '<span class="text-yellow-600 dark:text-yellow-500">Certificate generated but not installed in system trust store</span>';
+            text.innerHTML = '<span class="text-yellow-600 dark:text-yellow-500">Certificate generated but not trusted by your OS</span>';
             if (data.expiresAt) {
                 text.innerHTML += ' <span class="text-muted-foreground">&middot; expires ' + data.expiresAt.split('T')[0] + '</span>';
             }


### PR DESCRIPTION
## Summary

- `greyproxy install` now generates the CA certificate if missing and attempts to trust it via sudo on all install paths (fresh, reinstall, brew)
- Fixes brew install never generating or trusting certs
- If sudo fails (non-interactive brew postflight, user cancels), install continues and tells the user to run `greyproxy cert install`
- Simplifies README: merges duplicate install sections, removes redundant manual cert steps
- UI settings page now shows `greyproxy cert install` instead of raw sudo commands when cert is not trusted

## Test plan

- [ ] Fresh `greyproxy install` generates cert and prompts for sudo trust
- [ ] `greyproxy install` with existing trusted cert skips cert steps
- [ ] `greyproxy install -f` (brew postflight) generates and trusts cert without interactive prompt; continues gracefully if sudo fails
- [ ] Dashboard Settings > TLS tab shows `greyproxy cert install` when cert is not trusted
- [ ] `greyproxy uninstall` still removes trusted cert