### PR TITLE
feat: notification claims for companion apps

### DIFF
--- a/docs/control-websocket.md
+++ b/docs/control-websocket.md
@@ -1,0 +1,191 @@
+# Control WebSocket Protocol
+
+GreyProxy exposes a WebSocket endpoint at `GET /ws` that allows companion apps and external tools to receive real-time events and control the proxy.
+
+## Connection
+
+Connect to `ws://<host>:<port>/ws`. On success, the server sends:
+
+```json
+{
+  "type": "connected",
+  "message": "Connected to proxy event stream",
+  "timestamp": "2025-01-15T10:30:00Z"
+}
+```
+
+Each connection is assigned a random client ID (16 hex characters) for internal tracking.
+
+## Commands (client to server)
+
+All commands are JSON objects with a `command` field. Unknown commands return an error.
+
+### ping
+
+Keep-alive heartbeat.
+
+```json
+{"command": "ping"}
+```
+
+Response:
+
+```json
+{"type": "pong", "timestamp": "..."}
+```
+
+### allow
+
+Approve a pending request and create an allow rule.
+
+```json
+{
+  "command": "allow",
+  "pending_id": 123,
+  "scope": "exact",
+  "duration": "permanent",
+  "notes": "optional note"
+}
+```
+
+| Field | Default | Values |
+|-------|---------|--------|
+| `scope` | `"exact"` | `"exact"`, other scope values |
+| `duration` | `"permanent"` | `"permanent"`, Go duration string (e.g. `"1h"`, `"30m"`) |
+| `notes` | none | Free-text annotation |
+
+Response on success:
+
+```json
+{
+  "type": "command_success",
+  "command": "allow",
+  "pending_id": 123,
+  "rule_id": 456,
+  "timestamp": "..."
+}
+```
+
+### dismiss
+
+Dismiss a pending request without creating a rule.
+
+```json
+{"command": "dismiss", "pending_id": 123}
+```
+
+Response on success:
+
+```json
+{
+  "type": "command_success",
+  "command": "dismiss",
+  "pending_id": 123,
+  "timestamp": "..."
+}
+```
+
+### subscribe
+
+Filter which events this connection receives. By default, new connections receive all events. Sending `subscribe` switches the connection to filtered mode where only subscribed event types are forwarded.
+
+```json
+{"command": "subscribe", "event_type": "pending_request.created"}
+```
+
+Response:
+
+```json
+{"type": "subscribed", "event_type": "pending_request.created", "timestamp": "..."}
+```
+
+### unsubscribe
+
+Stop receiving a specific event type.
+
+```json
+{"command": "unsubscribe", "event_type": "pending_request.created"}
+```
+
+Response:
+
+```json
+{"type": "unsubscribed", "event_type": "pending_request.created", "timestamp": "..."}
+```
+
+### claim_notifications
+
+Tell the proxy that this connection is handling user notifications (e.g. a companion app showing its own UI). While at least one connection holds a claim, the proxy suppresses system desktop notifications (notify-send / terminal-notifier).
+
+```json
+{"command": "claim_notifications"}
+```
+
+Response:
+
+```json
+{
+  "type": "notification_claimed",
+  "active_claims": 1,
+  "timestamp": "..."
+}
+```
+
+The claim is automatically released when the WebSocket connection closes (disconnect, crash, network failure). If multiple connections claim notifications, all of them must disconnect before system notifications resume.
+
+Claiming twice on the same connection returns an error:
+
+```json
+{"type": "error", "error": "notifications already claimed by this connection", "timestamp": "..."}
+```
+
+When any claim count changes, all connected clients receive a broadcast:
+
+```json
+{"type": "notification.claims_changed", "data": {"active_claims": 0}}
+```
+
+## Events (server to client)
+
+Events are broadcast to all connected clients (filtered by subscriptions). Each event has a `type` and `data` field.
+
+| Event Type | Trigger | Data |
+|------------|---------|------|
+| `pending_request.created` | New pending connection request | `PendingRequest` object |
+| `pending_request.updated` | Pending request metadata changed | `PendingRequest` object |
+| `pending_request.allowed` | Pending request approved | `{pending_id, rule}` |
+| `pending_request.dismissed` | Pending request dismissed | `{pending_id}` |
+| `waiters.changed` | Active connection count changed for a pending | `{container_name, host, port, previous_count, current_count}` |
+| `transaction.new` | New HTTP/WS transaction recorded | Transaction object |
+| `conversation.updated` | Conversation dissector produced new data | Conversation object |
+| `maintenance.progress` | Background maintenance task progress | Progress object |
+| `allowall.changed` | Allow-all mode toggled | AllowAll status |
+| `notification.claims_changed` | Notification claim count changed | `{active_claims}` |
+
+## Errors
+
+All errors have the same shape:
+
+```json
+{"type": "error", "error": "description", "timestamp": "..."}
+```
+
+## Notification claim status via REST
+
+The `GET /api/notifications` endpoint also reports the current claim count:
+
+```json
+{"enabled": true, "active_claims": 1}
+```
+
+## Example: companion app flow
+
+```
+1. Connect to ws://<proxy>/ws
+2. Send: {"command": "claim_notifications"}
+3. Receive: {"type": "notification_claimed", "active_claims": 1}
+4. Listen for pending_request.created events
+5. Show native UI for each pending request
+6. Send allow/dismiss commands as the user decides
+7. On app exit: connection closes, claim auto-released
+```

--- a/internal/greyproxy/api/notifications.go
+++ b/internal/greyproxy/api/notifications.go
@@ -10,11 +10,18 @@ import (
 func NotificationsStatusHandler(s *Shared) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if s.Settings == nil {
-			c.JSON(http.StatusOK, gin.H{"enabled": false})
+			c.JSON(http.StatusOK, gin.H{"enabled": false, "active_claims": 0})
 			return
 		}
 		resolved := s.Settings.Get()
-		c.JSON(http.StatusOK, gin.H{"enabled": resolved.NotificationsEnabled})
+		activeClaims := 0
+		if s.Notifier != nil {
+			activeClaims = s.Notifier.ActiveClaims()
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"enabled":       resolved.NotificationsEnabled,
+			"active_claims": activeClaims,
+		})
 	}
 }
 

--- a/internal/greyproxy/api/settings.go
+++ b/internal/greyproxy/api/settings.go
@@ -33,14 +33,17 @@ type notificationSettingsResp struct {
 	Backend         string `json:"backend"`
 	InstallHint     string `json:"installHint,omitempty"`
 	SupportsActions bool   `json:"supportsActions"`
+	ActiveClaims    int    `json:"activeClaims"`
 }
 
 func buildSettingsResponse(s *Shared) settingsResponse {
 	resolved := s.Settings.Get()
 
 	var info greyproxy.NotificationBackendInfo
+	var activeClaims int
 	if s.Notifier != nil {
 		info = s.Notifier.BackendInfo()
+		activeClaims = s.Notifier.ActiveClaims()
 	}
 
 	certStatus := buildCertStatus(s.DataHome)
@@ -64,6 +67,7 @@ func buildSettingsResponse(s *Shared) settingsResponse {
 			Backend:         info.Backend,
 			InstallHint:     info.InstallHint,
 			SupportsActions: info.SupportsActions,
+			ActiveClaims:    activeClaims,
 		},
 		Mitm: mitm,
 	}

--- a/internal/greyproxy/api/websocket.go
+++ b/internal/greyproxy/api/websocket.go
@@ -262,9 +262,9 @@ func handleClientCommands(client *wsClient, s *Shared, log logger.Logger) {
 		case "claim_notifications":
 			if client.notifClaimed {
 				_ = client.send(gin.H{
-					"type":          "error",
-					"error":         "notifications already claimed by this connection",
-					"timestamp":     time.Now().UTC().Format(time.RFC3339),
+					"type":      "error",
+					"error":     "notifications already claimed by this connection",
+					"timestamp": time.Now().UTC().Format(time.RFC3339),
 				})
 				continue
 			}

--- a/internal/greyproxy/api/websocket.go
+++ b/internal/greyproxy/api/websocket.go
@@ -30,6 +30,7 @@ type wsClient struct {
 	mu            sync.Mutex
 	subscriptions map[string]bool // nil means "subscribe to all"
 	subMu         sync.RWMutex
+	notifClaimed  bool // true if this client claimed notifications
 }
 
 func (c *wsClient) send(msg any) error {
@@ -95,6 +96,18 @@ func WebSocketHandler(s *Shared) gin.HandlerFunc {
 		go func() {
 			defer close(done)
 			handleClientCommands(client, s, log)
+		}()
+
+		// Release notification claim on disconnect
+		defer func() {
+			if client.notifClaimed && s.Notifier != nil {
+				count := s.Notifier.ReleaseNotifications()
+				log.Infof("ws client %s disconnected, auto-released notification claim (active claims: %d)", client.id, count)
+				s.Bus.Publish(greyproxy.Event{
+					Type: greyproxy.EventNotificationClaimsChanged,
+					Data: map[string]any{"active_claims": count},
+				})
+			}
 		}()
 
 		// Forward events to client (filtered by subscriptions)
@@ -244,6 +257,35 @@ func handleClientCommands(client *wsClient, s *Shared, log logger.Logger) {
 				"type":       "unsubscribed",
 				"event_type": cmd.EventType,
 				"timestamp":  time.Now().UTC().Format(time.RFC3339),
+			})
+
+		case "claim_notifications":
+			if client.notifClaimed {
+				_ = client.send(gin.H{
+					"type":          "error",
+					"error":         "notifications already claimed by this connection",
+					"timestamp":     time.Now().UTC().Format(time.RFC3339),
+				})
+				continue
+			}
+			if s.Notifier == nil {
+				_ = client.send(gin.H{
+					"type":      "error",
+					"error":     "notifier not available",
+					"timestamp": time.Now().UTC().Format(time.RFC3339),
+				})
+				continue
+			}
+			client.notifClaimed = true
+			count := s.Notifier.ClaimNotifications()
+			s.Bus.Publish(greyproxy.Event{
+				Type: greyproxy.EventNotificationClaimsChanged,
+				Data: map[string]any{"active_claims": count},
+			})
+			_ = client.send(gin.H{
+				"type":          "notification_claimed",
+				"active_claims": count,
+				"timestamp":     time.Now().UTC().Format(time.RFC3339),
 			})
 
 		default:

--- a/internal/greyproxy/events.go
+++ b/internal/greyproxy/events.go
@@ -22,6 +22,9 @@ const (
 
 	// Allow-all mode events
 	EventAllowAllChanged = "allowall.changed"
+
+	// Notification claim events
+	EventNotificationClaimsChanged = "notification.claims_changed"
 )
 
 // Event represents a broadcast event.

--- a/internal/greyproxy/notifier.go
+++ b/internal/greyproxy/notifier.go
@@ -48,6 +48,11 @@ type Notifier struct {
 	activeNotifMu sync.Mutex
 	activeNotif   map[int64]*os.Process
 
+	// Notification claims: when > 0, a companion app is handling
+	// notifications and system notifications are suppressed.
+	claimsMu sync.Mutex
+	claims   int
+
 	stop chan struct{}
 }
 
@@ -271,9 +276,47 @@ func (n *Notifier) Enabled() bool {
 	return n.enabled.Load()
 }
 
+// ClaimNotifications increments the claim counter, suppressing system
+// notifications while at least one claim is active. Returns the new count.
+func (n *Notifier) ClaimNotifications() int {
+	n.claimsMu.Lock()
+	n.claims++
+	count := n.claims
+	n.claimsMu.Unlock()
+	n.log.Infof("notification claimed (active claims: %d)", count)
+	return count
+}
+
+// ReleaseNotifications decrements the claim counter. When it reaches zero,
+// system notifications resume. Returns the new count.
+func (n *Notifier) ReleaseNotifications() int {
+	n.claimsMu.Lock()
+	if n.claims > 0 {
+		n.claims--
+	}
+	count := n.claims
+	n.claimsMu.Unlock()
+	n.log.Infof("notification released (active claims: %d)", count)
+	return count
+}
+
+// ActiveClaims returns the current number of notification claims.
+func (n *Notifier) ActiveClaims() int {
+	n.claimsMu.Lock()
+	defer n.claimsMu.Unlock()
+	return n.claims
+}
+
+// claimed returns true if notifications are currently claimed by a companion.
+func (n *Notifier) claimed() bool {
+	n.claimsMu.Lock()
+	defer n.claimsMu.Unlock()
+	return n.claims > 0
+}
+
 // onPendingCreated handles a brand new pending request; always notify.
 func (n *Notifier) onPendingCreated(evt Event) {
-	if !n.enabled.Load() {
+	if !n.enabled.Load() || n.claimed() {
 		return
 	}
 
@@ -291,7 +334,7 @@ func (n *Notifier) onPendingCreated(evt Event) {
 
 // onWaitersChanged handles when a pending goes from 0 waiters to 1+.
 func (n *Notifier) onWaitersChanged(evt Event) {
-	if !n.enabled.Load() {
+	if !n.enabled.Load() || n.claimed() {
 		return
 	}
 

--- a/internal/greyproxy/ui/templates/settings.html
+++ b/internal/greyproxy/ui/templates/settings.html
@@ -85,6 +85,19 @@
                 </div>
             </div>
 
+            <!-- Claimed hint (shown when a companion app holds notification claims) -->
+            <div id="notif-claimed-hint" class="hidden mt-4 p-4 bg-muted rounded-lg border border-border">
+                <div class="flex items-start gap-3">
+                    <svg class="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                    </svg>
+                    <div>
+                        <p class="font-medium text-foreground">Notifications handled by companion</p>
+                        <p id="notif-claimed-text" class="mt-1 text-muted-foreground">A companion app is handling notifications. System notifications are suppressed while the companion is connected.</p>
+                    </div>
+                </div>
+            </div>
+
             <!-- Basic mode hint (shown when notify-send is old and lacks actions) -->
             <div id="notif-basic-hint" class="hidden mt-4 p-4 bg-muted rounded-lg border border-border">
                 <div class="flex items-start gap-3">
@@ -508,23 +521,35 @@
         var hintEl = document.getElementById('notif-install-hint');
         var hintTextEl = document.getElementById('notif-install-text');
         var basicHintEl = document.getElementById('notif-basic-hint');
+        var claimedHintEl = document.getElementById('notif-claimed-hint');
+        var claimedTextEl = document.getElementById('notif-claimed-text');
 
         if (!data.available) {
             statusEl.innerHTML = '<span class="text-muted-foreground">No notification backend available</span>';
             hintEl.classList.remove('hidden');
             basicHintEl.classList.add('hidden');
+            claimedHintEl.classList.add('hidden');
             hintTextEl.textContent = data.installHint || 'Desktop notifications are not supported on this platform.';
         } else {
             var status = data.enabled ? 'Enabled' : 'Disabled';
             var statusColor = data.enabled ? 'text-[var(--color-green)]' : 'text-muted-foreground';
             var mode = data.supportsActions ? '' : ' (basic)';
-            statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + '</span>' +
+            var claimed = data.activeClaims > 0;
+            var claimedLabel = claimed ? ' (companion)' : '';
+            statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + claimedLabel + '</span>' +
                 ' <span class="text-muted-foreground">&middot; Using ' + data.backend + '</span>';
             hintEl.classList.add('hidden');
             if (!data.supportsActions && data.enabled) {
                 basicHintEl.classList.remove('hidden');
             } else {
                 basicHintEl.classList.add('hidden');
+            }
+            if (claimed && data.enabled) {
+                var plural = data.activeClaims > 1 ? data.activeClaims + ' companion apps are' : 'A companion app is';
+                claimedTextEl.textContent = plural + ' handling notifications. System notifications are suppressed while connected.';
+                claimedHintEl.classList.remove('hidden');
+            } else {
+                claimedHintEl.classList.add('hidden');
             }
         }
     }

--- a/internal/greyproxy/ui/templates/settings.html
+++ b/internal/greyproxy/ui/templates/settings.html
@@ -86,16 +86,8 @@
             </div>
 
             <!-- Claimed hint (shown when a companion app holds notification claims) -->
-            <div id="notif-claimed-hint" class="hidden mt-4 p-4 bg-muted rounded-lg border border-border">
-                <div class="flex items-start gap-3">
-                    <svg class="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-                    </svg>
-                    <div>
-                        <p class="font-medium text-foreground">Notifications handled by companion</p>
-                        <p id="notif-claimed-text" class="mt-1 text-muted-foreground">A companion app is handling notifications. System notifications are suppressed while the companion is connected.</p>
-                    </div>
-                </div>
+            <div id="notif-claimed-hint" class="hidden mt-3 text-xs text-muted-foreground">
+                <span id="notif-claimed-text">A companion app is handling notifications. System notifications are suppressed while the companion is connected.</span>
             </div>
 
             <!-- Basic mode hint (shown when notify-send is old and lacks actions) -->
@@ -535,9 +527,13 @@
             var statusColor = data.enabled ? 'text-[var(--color-green)]' : 'text-muted-foreground';
             var mode = data.supportsActions ? '' : ' (basic)';
             var claimed = data.activeClaims > 0;
-            var claimedLabel = claimed ? ' (companion)' : '';
-            statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + claimedLabel + '</span>' +
-                ' <span class="text-muted-foreground">&middot; Using ' + data.backend + '</span>';
+            if (claimed && data.enabled) {
+                statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + '</span>' +
+                    ' <span class="text-muted-foreground">&middot; Handled by companion</span>';
+            } else {
+                statusEl.innerHTML = '<span class="' + statusColor + '">' + status + mode + '</span>' +
+                    ' <span class="text-muted-foreground">&middot; Using ' + data.backend + '</span>';
+            }
             hintEl.classList.add('hidden');
             if (!data.supportsActions && data.enabled) {
                 basicHintEl.classList.remove('hidden');


### PR DESCRIPTION
## Summary

- Adds `claim_notifications` WebSocket command that lets companion apps suppress system desktop notifications while they handle notifications themselves
- Reference-counted: multiple clients can claim, all must disconnect before system notifications resume
- Auto-released on WebSocket disconnect (crash-safe)
- Settings page shows "(companion)" label and info box when claims are active
- `GET /api/notifications` and `GET /api/settings` both expose `active_claims` count
- New `docs/control-websocket.md` documenting the full control WebSocket protocol

## Test plan

- [x] Connect via WebSocket, send `{"command": "claim_notifications"}`, verify system notifications stop
- [x] Disconnect the WebSocket, verify system notifications resume
- [x] Connect two clients with claims, disconnect one, verify notifications still suppressed
- [x] Disconnect the second, verify notifications resume
- [x] Check settings page shows companion hint when a claim is active
- [ ] Verify `claim_notifications` twice on the same connection returns an error