### PR TITLE
Session-scoped network rules with layered resolution

### DIFF
--- a/docs/session-network-rules-plan.md
+++ b/docs/session-network-rules-plan.md
@@ -1,0 +1,209 @@
+# Session-Scoped Network Rules Plan
+
+## Problem
+
+Greywall profiles manage credentials and filesystem rules, but not network rules. Network rules live in greyproxy's SQLite DB as global permanent/temporary entries. When a user runs `greywall --profile codex`, they must manually approve every network destination through the dashboard. This is the #1 friction point from user feedback.
+
+## Solution Overview
+
+1. **greyproxy**: Accept network rules as part of session creation, scope them to session lifetime, auto-cleanup on session end/expire.
+2. **greywall**: Add network rule presets to profiles, send them with session creation, refine `--learning` to extend defaults.
+
+## Current Flow (broken)
+
+```
+greywall --profile codex
+  -> POST /api/sessions (credentials only)
+  -> codex tries api.openai.com -> no rule -> pending -> user clicks allow
+  -> repeat for every domain, every session
+```
+
+## Proposed Flow
+
+```
+greywall --profile codex
+  -> POST /api/sessions (credentials + network rules from profile)
+  -> codex tries api.openai.com -> session rule matches -> allowed instantly
+  -> session ends -> session-scoped rules auto-deleted
+```
+
+---
+
+## greyproxy Changes
+
+### 1. DB Migration
+
+Add `session_id` column to `rules` table:
+
+```sql
+ALTER TABLE rules ADD COLUMN session_id TEXT DEFAULT NULL;
+CREATE INDEX idx_rules_session_id ON rules(session_id);
+```
+
+Add `allow_all` column to `sessions` table:
+
+```sql
+ALTER TABLE sessions ADD COLUMN allow_all INTEGER DEFAULT 0;
+```
+
+Seed built-in localhost rules:
+
+```sql
+INSERT INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+VALUES ('*', '127.0.0.1', '*', 'builtin', 'allow', 'builtin');
+INSERT INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+VALUES ('*', '::1', '*', 'builtin', 'allow', 'builtin');
+INSERT INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+VALUES ('*', 'localhost', '*', 'builtin', 'allow', 'builtin');
+```
+
+### 2. API Change: POST /api/sessions
+
+Add optional `network_rules` and `allow_all` fields:
+
+```json
+{
+  "session_id": "uuid",
+  "container_name": "codex",
+  "mappings": { ... },
+  "network_rules": [
+    { "destination_pattern": "api.openai.com", "port_pattern": "443", "action": "allow" },
+    { "destination_pattern": "**.openai.com", "port_pattern": "443", "action": "allow" }
+  ],
+  "allow_all": false,
+  "ttl_seconds": 900
+}
+```
+
+Response adds `rules_created` count.
+
+### 3. Layered Rule Resolution
+
+Rules have three source layers, evaluated in priority order:
+
+| Priority | Source | How identified |
+|---|---|---|
+| 1 (highest) | Global | `session_id IS NULL AND created_by != 'builtin'` |
+| 2 | Session | `session_id IS NOT NULL` |
+| 3 (lowest) | Built-in | `created_by = 'builtin'` |
+
+Resolution: highest layer match wins. Within same layer, highest specificity wins. Deny beats allow at same specificity within same layer.
+
+This means:
+- Global deny always blocks, even if profile says allow (strict mode)
+- Global allow always permits, even if profile doesn't include it
+- Session rules fill the gap for common tool destinations
+- Built-in localhost rules are lowest priority, overridable by session or global deny
+
+### 4. Per-Container AllowAll
+
+When a session has `allow_all = true`, greyproxy skips ACL evaluation for that container. Used by `--learning` mode. Only affects the specific container, not global traffic.
+
+### 5. Session Rule Lifecycle
+
+| Event | Effect on session rules |
+|---|---|
+| Session created | Rules inserted with session_id, expires_at from session TTL |
+| Session heartbeat | Rules' expires_at extended to match new session expiry |
+| Session deleted | Rules deleted |
+| Session expired | Background cleanup deletes rules alongside session |
+| Session upserted | Old session rules deleted, new ones inserted |
+
+---
+
+## greywall Changes
+
+### 1. Config Extension
+
+Add `NetworkRule` type and `Rules` field to `NetworkConfig`:
+
+```go
+type NetworkRule struct {
+    Destination string `json:"destination"`
+    Port        string `json:"port,omitempty"`    // default "*"
+    Action      string `json:"action,omitempty"`  // default "allow"
+    Notes       string `json:"notes,omitempty"`
+}
+
+type NetworkConfig struct {
+    // ... existing fields
+    Rules []NetworkRule `json:"rules,omitempty"`
+}
+```
+
+### 2. Agent Profile Defaults
+
+Each agent profile gets network rules for its known API endpoints:
+
+| Profile | Default allow destinations |
+|---|---|
+| claude | api.anthropic.com:443, **.anthropic.com:443, github.com:443, *.githubusercontent.com:443 |
+| codex | api.openai.com:443, **.openai.com:443 |
+| opencode | api.openai.com:443, api.anthropic.com:443 |
+| aider | api.openai.com:443, api.anthropic.com:443 |
+| cursor | api2.cursor.sh:443, api.openai.com:443, api.anthropic.com:443 |
+| gemini | generativelanguage.googleapis.com:443 |
+| goose | api.openai.com:443, api.anthropic.com:443 |
+| amp | api.anthropic.com:443, api.openai.com:443 |
+| copilot | api.github.com:443, copilot-proxy.githubusercontent.com:443 |
+| cline | api.anthropic.com:443, api.openai.com:443 |
+| Others | api.openai.com:443, api.anthropic.com:443 (safe default) |
+
+### 3. Session Creation with Network Rules
+
+`RegisterSession()` sends merged network rules (profile defaults + user overrides + CLI flags) as `network_rules` in the session request.
+
+New CLI flag: `--allow PATTERN` adds a one-off allow rule for the session.
+
+### 4. Learning Mode Refinement
+
+`--learning` (existing flag):
+- Loads default profile for the tool
+- Sends profile network rules to greyproxy
+- Sets `allow_all: true` on the session (everything goes through)
+- On session end: queries logs, filters out known profile destinations, shows new ones
+- Offers to save discovered destinations to user profile
+
+`--learning --blank` (new flag):
+- Skips default profile network rules
+- Sets `allow_all: true` only
+- Shows ALL destinations in summary (for auditing or untrusted defaults)
+
+### 5. Post-Learning Output
+
+```
+[greywall] Learning session complete for "codex"
+
+  Default profile rules (3 rules, already known):
+    ok api.openai.com:443
+    ok **.openai.com:443
+    ok 127.0.0.1:*
+
+  New destinations discovered (2):
+    + sentry.io:443           (4 requests)
+    + registry.npmjs.org:443  (17 requests)
+
+  Add to profile? [Y/n] y
+  Saved to ~/.config/greywall/learned/codex.json
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: greyproxy (this repo)
+1. Migration: session_id on rules, allow_all on sessions, built-in localhost rules
+2. Extend SessionCreateInput with NetworkRules and AllowAll
+3. Session rule CRUD (create/delete/heartbeat-extend)
+4. Layered FindMatchingRule resolution
+5. Per-container allow_all check
+6. API handler updates
+7. Tests
+
+### Phase 2: greywall (separate repo)
+1. NetworkRule type in config
+2. Network rules in agent profiles
+3. Send network_rules in RegisterSession
+4. --allow CLI flag
+5. --blank flag for learning
+6. Post-learning log query and profile save

--- a/internal/greyproxy/api/sessions.go
+++ b/internal/greyproxy/api/sessions.go
@@ -83,8 +83,8 @@ func SessionsCreateHandler(s *Shared) gin.HandlerFunc {
 			}
 		}
 
-		if len(input.Mappings) == 0 && len(resolvedGlobals) == 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no credentials provided (mappings or global_credentials required)"})
+		if len(input.Mappings) == 0 && len(resolvedGlobals) == 0 && len(input.NetworkRules) == 0 && !input.AllowAll {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no credentials or network rules provided"})
 			return
 		}
 
@@ -105,10 +105,13 @@ func SessionsCreateHandler(s *Shared) gin.HandlerFunc {
 			s.CredentialStore.RegisterSession(session, input.Mappings)
 		}
 
+		rulesCreated := greyproxy.GetSessionRuleCount(s.DB, session.SessionID)
+
 		resp := gin.H{
 			"session_id":       session.SessionID,
 			"expires_at":       session.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z"),
 			"credential_count": len(input.Mappings) + len(resolvedGlobals),
+			"rules_created":    rulesCreated,
 		}
 		if resolvedGlobals != nil {
 			resp["global_credentials"] = resolvedGlobals

--- a/internal/greyproxy/credential_crud.go
+++ b/internal/greyproxy/credential_crud.go
@@ -10,13 +10,15 @@ import (
 // --- Sessions ---
 
 type SessionCreateInput struct {
-	SessionID         string            `json:"session_id"`
-	ContainerName     string            `json:"container_name"`
-	Mappings          map[string]string `json:"mappings"`
-	Labels            map[string]string `json:"labels"`
-	Metadata          map[string]string `json:"metadata"`
-	TTLSeconds        int               `json:"ttl_seconds"`
-	GlobalCredentials []string          `json:"global_credentials,omitempty"`
+	SessionID         string               `json:"session_id"`
+	ContainerName     string               `json:"container_name"`
+	Mappings          map[string]string    `json:"mappings"`
+	Labels            map[string]string    `json:"labels"`
+	Metadata          map[string]string    `json:"metadata"`
+	TTLSeconds        int                  `json:"ttl_seconds"`
+	GlobalCredentials []string             `json:"global_credentials,omitempty"`
+	NetworkRules      []SessionNetworkRule `json:"network_rules,omitempty"`
+	AllowAll          bool                 `json:"allow_all,omitempty"`
 }
 
 // CreateOrUpdateSession creates or upserts a credential substitution session.
@@ -53,9 +55,14 @@ func CreateOrUpdateSession(db *DB, input SessionCreateInput, encryptionKey []byt
 		return nil, fmt.Errorf("marshal metadata: %w", err)
 	}
 
+	allowAllInt := 0
+	if input.AllowAll {
+		allowAllInt = 1
+	}
+
 	_, err = db.WriteDB().Exec(
-		`INSERT INTO sessions (session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds, created_at, expires_at, last_heartbeat)
-		 VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now', '+' || ? || ' seconds'), datetime('now'))
+		`INSERT INTO sessions (session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds, created_at, expires_at, last_heartbeat, allow_all)
+		 VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now', '+' || ? || ' seconds'), datetime('now'), ?)
 		 ON CONFLICT(session_id) DO UPDATE SET
 		   container_name = excluded.container_name,
 		   mappings_enc = excluded.mappings_enc,
@@ -63,12 +70,39 @@ func CreateOrUpdateSession(db *DB, input SessionCreateInput, encryptionKey []byt
 		   metadata_json = excluded.metadata_json,
 		   ttl_seconds = excluded.ttl_seconds,
 		   expires_at = excluded.expires_at,
-		   last_heartbeat = excluded.last_heartbeat`,
+		   last_heartbeat = excluded.last_heartbeat,
+		   allow_all = excluded.allow_all`,
 		input.SessionID, input.ContainerName, mappingsEnc, string(labelsJSON), string(metadataJSON),
-		input.TTLSeconds, input.TTLSeconds,
+		input.TTLSeconds, input.TTLSeconds, allowAllInt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("upsert session: %w", err)
+	}
+
+	// On upsert, delete old session rules before creating new ones.
+	_, _ = db.WriteDB().Exec("DELETE FROM rules WHERE session_id = ?", input.SessionID)
+
+	// Create session-scoped network rules.
+	if len(input.NetworkRules) > 0 {
+		for _, nr := range input.NetworkRules {
+			port := nr.PortPattern
+			if port == "" {
+				port = "*"
+			}
+			action := nr.Action
+			if action == "" {
+				action = "allow"
+			}
+			_, err := db.WriteDB().Exec(
+				`INSERT OR IGNORE INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by, session_id, expires_at, notes)
+				 VALUES (?, ?, ?, 'temporary', ?, ?, ?, datetime('now', '+' || ? || ' seconds'), ?)`,
+				input.ContainerName, nr.DestinationPattern, port, action,
+				"session:"+input.SessionID, input.SessionID, input.TTLSeconds, nr.Notes,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("create session rule %q: %w", nr.DestinationPattern, err)
+			}
+		}
 	}
 
 	// Re-read from DB to get the canonical timestamps
@@ -97,13 +131,23 @@ func HeartbeatSession(db *DB, sessionID string) (*Session, error) {
 		return nil, nil // not found or expired
 	}
 
+	// Extend session-scoped rules to match the new session expiry.
+	_, _ = db.WriteDB().Exec(
+		`UPDATE rules SET expires_at = (SELECT expires_at FROM sessions WHERE session_id = ?)
+		 WHERE session_id = ?`,
+		sessionID, sessionID,
+	)
+
 	return getSessionLocked(db, sessionID)
 }
 
-// DeleteSession removes a session from the database.
+// DeleteSession removes a session and its scoped network rules from the database.
 func DeleteSession(db *DB, sessionID string) (bool, error) {
 	db.Lock()
 	defer db.Unlock()
+
+	// Delete session-scoped rules first.
+	_, _ = db.WriteDB().Exec("DELETE FROM rules WHERE session_id = ?", sessionID)
 
 	result, err := db.WriteDB().Exec("DELETE FROM sessions WHERE session_id = ?", sessionID)
 	if err != nil {
@@ -117,7 +161,7 @@ func DeleteSession(db *DB, sessionID string) (bool, error) {
 func GetSession(db *DB, sessionID string) (*Session, error) {
 	return scanSession(db.ReadDB().QueryRow(
 		`SELECT session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds,
-		        created_at, expires_at, last_heartbeat, substitution_count
+		        created_at, expires_at, last_heartbeat, substitution_count, allow_all
 		 FROM sessions WHERE session_id = ?`, sessionID,
 	))
 }
@@ -126,7 +170,7 @@ func GetSession(db *DB, sessionID string) (*Session, error) {
 func ListSessions(db *DB) ([]Session, error) {
 	rows, err := db.ReadDB().Query(
 		`SELECT session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds,
-		        created_at, expires_at, last_heartbeat, substitution_count
+		        created_at, expires_at, last_heartbeat, substitution_count, allow_all
 		 FROM sessions WHERE expires_at > datetime('now') ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -179,6 +223,11 @@ func DeleteExpiredSessions(db *DB) ([]string, error) {
 	}
 
 	if len(ids) > 0 {
+		// Delete session-scoped rules for all expired sessions.
+		for _, id := range ids {
+			_, _ = db.WriteDB().Exec("DELETE FROM rules WHERE session_id = ?", id)
+		}
+
 		_, err = db.WriteDB().Exec(
 			"DELETE FROM sessions WHERE expires_at <= ?", now,
 		)
@@ -188,6 +237,26 @@ func DeleteExpiredSessions(db *DB) ([]string, error) {
 	}
 
 	return ids, nil
+}
+
+// IsContainerAllowAll checks if the given container has an active session with allow_all enabled.
+func IsContainerAllowAll(db *DB, containerName string) bool {
+	var count int
+	err := db.ReadDB().QueryRow(
+		`SELECT COUNT(*) FROM sessions
+		 WHERE container_name = ? AND allow_all = 1 AND expires_at > datetime('now')`,
+		containerName,
+	).Scan(&count)
+	return err == nil && count > 0
+}
+
+// GetSessionRuleCount returns the number of active session-scoped rules for a session.
+func GetSessionRuleCount(db *DB, sessionID string) int {
+	var count int
+	_ = db.ReadDB().QueryRow(
+		"SELECT COUNT(*) FROM rules WHERE session_id = ?", sessionID,
+	).Scan(&count)
+	return count
 }
 
 // IncrementSubstitutionCount atomically increments the substitution counter for a session.
@@ -206,7 +275,7 @@ func IncrementSubstitutionCount(db *DB, sessionID string, delta int64) error {
 func LoadAllSessions(db *DB) ([]Session, error) {
 	rows, err := db.ReadDB().Query(
 		`SELECT session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds,
-		        created_at, expires_at, last_heartbeat, substitution_count
+		        created_at, expires_at, last_heartbeat, substitution_count, allow_all
 		 FROM sessions ORDER BY created_at`,
 	)
 	if err != nil {
@@ -229,7 +298,7 @@ func LoadAllSessions(db *DB) ([]Session, error) {
 func getSessionLocked(db *DB, sessionID string) (*Session, error) {
 	return scanSession(db.WriteDB().QueryRow(
 		`SELECT session_id, container_name, mappings_enc, labels_json, metadata_json, ttl_seconds,
-		        created_at, expires_at, last_heartbeat, substitution_count
+		        created_at, expires_at, last_heartbeat, substitution_count, allow_all
 		 FROM sessions WHERE session_id = ?`, sessionID,
 	))
 }
@@ -242,7 +311,7 @@ func scanSession(row scannable) (*Session, error) {
 	var s Session
 	err := row.Scan(
 		&s.SessionID, &s.ContainerName, &s.MappingsEnc, &s.LabelsJSON, &s.MetadataJSON,
-		&s.TTLSeconds, &s.CreatedAt, &s.ExpiresAt, &s.LastHeartbeat, &s.SubstitutionCount,
+		&s.TTLSeconds, &s.CreatedAt, &s.ExpiresAt, &s.LastHeartbeat, &s.SubstitutionCount, &s.AllowAll,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/greyproxy/crud.go
+++ b/internal/greyproxy/crud.go
@@ -92,6 +92,10 @@ func CreateRule(db *DB, input RuleCreateInput) (*Rule, error) {
 const ruleColumns = `id, container_pattern, destination_pattern, port_pattern,
 	rule_type, action, created_at, expires_at, last_used_at, created_by, notes, session_id`
 
+// ruleColumnsQualified is the SELECT list with rules. prefix for use in JOIN queries.
+const ruleColumnsQualified = `rules.id, rules.container_pattern, rules.destination_pattern, rules.port_pattern,
+	rules.rule_type, rules.action, rules.created_at, rules.expires_at, rules.last_used_at, rules.created_by, rules.notes, rules.session_id`
+
 func GetRule(db *DB, id int64) (*Rule, error) {
 	row := db.ReadDB().QueryRow(
 		`SELECT `+ruleColumns+` FROM rules WHERE id = ?`, id,
@@ -318,10 +322,29 @@ func IngestRules(db *DB, rules []IngestRuleInput) (*IngestResult, error) {
 // The highest-layer match wins. Within the same layer, highest specificity wins,
 // and deny beats allow at the same specificity.
 func FindMatchingRule(db *DB, containerName, destHost string, destPort int, resolvedHostname string) *Rule {
-	// Get all non-expired rules
+	// Get all non-expired rules. For session-scoped rules, JOIN with sessions and
+	// enforce two conditions:
+	//   1. The session itself is still active (not expired/deleted).
+	//   2. The session is the most recently created active session for this container.
+	//      This prevents an older session's rules from bleeding into a newer session
+	//      that was started with a different (or empty) rule set.
+	// Global and built-in rules (session_id IS NULL) are unaffected.
 	rows, err := db.ReadDB().Query(
-		`SELECT `+ruleColumns+` FROM rules
-		 WHERE expires_at IS NULL OR expires_at > datetime('now')`,
+		`SELECT `+ruleColumnsQualified+`
+		 FROM rules
+		 LEFT JOIN sessions ON rules.session_id = sessions.session_id
+		 WHERE (rules.expires_at IS NULL OR rules.expires_at > datetime('now'))
+		   AND (rules.session_id IS NULL
+		        OR (sessions.session_id IS NOT NULL
+		            AND sessions.expires_at > datetime('now')
+		            AND sessions.session_id = (
+		                SELECT session_id FROM sessions
+		                WHERE container_name = ?
+		                  AND expires_at > datetime('now')
+		                ORDER BY created_at DESC, rowid DESC
+		                LIMIT 1
+		            )))`,
+		containerName,
 	)
 	if err != nil {
 		return nil

--- a/internal/greyproxy/crud.go
+++ b/internal/greyproxy/crud.go
@@ -90,7 +90,7 @@ func CreateRule(db *DB, input RuleCreateInput) (*Rule, error) {
 
 // ruleColumns is the SELECT list for all rule queries.
 const ruleColumns = `id, container_pattern, destination_pattern, port_pattern,
-	rule_type, action, created_at, expires_at, last_used_at, created_by, notes`
+	rule_type, action, created_at, expires_at, last_used_at, created_by, notes, session_id`
 
 func GetRule(db *DB, id int64) (*Rule, error) {
 	row := db.ReadDB().QueryRow(
@@ -102,7 +102,7 @@ func GetRule(db *DB, id int64) (*Rule, error) {
 func scanRule(row interface{ Scan(...any) error }) (*Rule, error) {
 	var r Rule
 	err := row.Scan(&r.ID, &r.ContainerPattern, &r.DestinationPattern, &r.PortPattern,
-		&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes)
+		&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes, &r.SessionID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -166,7 +166,7 @@ func GetRules(db *DB, f RuleFilter) ([]Rule, int, error) {
 	for rows.Next() {
 		var r Rule
 		if err := rows.Scan(&r.ID, &r.ContainerPattern, &r.DestinationPattern, &r.PortPattern,
-			&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes); err != nil {
+			&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes, &r.SessionID); err != nil {
 			return nil, 0, err
 		}
 		rules = append(rules, r)
@@ -308,10 +308,19 @@ func IngestRules(db *DB, rules []IngestRuleInput) (*IngestResult, error) {
 
 // FindMatchingRule finds the most specific matching rule for the given request.
 // Returns nil if no rule matches (default-deny).
+//
+// Resolution uses a layered model:
+//
+//	Layer 1 (highest): Global rules (human-created via UI/API)
+//	Layer 2:           Session rules (from greywall profile, scoped to session lifetime)
+//	Layer 3 (lowest):  Built-in rules (localhost defaults)
+//
+// The highest-layer match wins. Within the same layer, highest specificity wins,
+// and deny beats allow at the same specificity.
 func FindMatchingRule(db *DB, containerName, destHost string, destPort int, resolvedHostname string) *Rule {
 	// Get all non-expired rules
 	rows, err := db.ReadDB().Query(
-		`SELECT ` + ruleColumns + ` FROM rules
+		`SELECT `+ruleColumns+` FROM rules
 		 WHERE expires_at IS NULL OR expires_at > datetime('now')`,
 	)
 	if err != nil {
@@ -320,15 +329,16 @@ func FindMatchingRule(db *DB, containerName, destHost string, destPort int, reso
 	defer func() { _ = rows.Close() }()
 
 	type scored struct {
-		rule        Rule
-		specificity int
+		rule           Rule
+		specificity    int
+		sourcePriority int
 	}
 
 	var matches []scored
 	for rows.Next() {
 		var r Rule
 		if err := rows.Scan(&r.ID, &r.ContainerPattern, &r.DestinationPattern, &r.PortPattern,
-			&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes); err != nil {
+			&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes, &r.SessionID); err != nil {
 			continue
 		}
 
@@ -345,8 +355,9 @@ func FindMatchingRule(db *DB, containerName, destHost string, destPort int, reso
 		}
 
 		matches = append(matches, scored{
-			rule:        r,
-			specificity: CalculateSpecificity(r.ContainerPattern, r.DestinationPattern, r.PortPattern),
+			rule:           r,
+			specificity:    CalculateSpecificity(r.ContainerPattern, r.DestinationPattern, r.PortPattern),
+			sourcePriority: r.RuleSourcePriority(),
 		})
 	}
 
@@ -354,8 +365,12 @@ func FindMatchingRule(db *DB, containerName, destHost string, destPort int, reso
 		return nil
 	}
 
-	// Sort: highest specificity first, deny before allow at same specificity
+	// Sort: source layer first (global > session > builtin),
+	// then specificity within same layer, then deny before allow at same specificity.
 	sort.Slice(matches, func(i, j int) bool {
+		if matches[i].sourcePriority != matches[j].sourcePriority {
+			return matches[i].sourcePriority > matches[j].sourcePriority
+		}
 		if matches[i].specificity != matches[j].specificity {
 			return matches[i].specificity > matches[j].specificity
 		}
@@ -786,7 +801,7 @@ func findExistingRule(db *DB, containerPattern, destPattern, portPattern, action
 		   AND (expires_at IS NULL OR expires_at > datetime('now'))`,
 		containerPattern, destPattern, portPattern, action,
 	).Scan(&r.ID, &r.ContainerPattern, &r.DestinationPattern, &r.PortPattern,
-		&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes)
+		&r.RuleType, &r.Action, &r.CreatedAt, &r.ExpiresAt, &r.LastUsedAt, &r.CreatedBy, &r.Notes, &r.SessionID)
 	if err != nil {
 		return nil
 	}

--- a/internal/greyproxy/crud_test.go
+++ b/internal/greyproxy/crud_test.go
@@ -33,6 +33,15 @@ func setupTestDB(t *testing.T) *DB {
 	return db
 }
 
+// clearBuiltinRules removes the seeded localhost rules so tests start with a clean slate.
+func clearBuiltinRules(t *testing.T, db *DB) {
+	t.Helper()
+	_, err := db.WriteDB().Exec("DELETE FROM rules WHERE created_by = 'builtin'")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCreateAndGetRule(t *testing.T) {
 	db := setupTestDB(t)
 
@@ -115,6 +124,7 @@ func TestCreateRuleWithExpiration(t *testing.T) {
 
 func TestTemporaryRuleVisibleInGetRules(t *testing.T) {
 	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
 
 	// Create a temporary rule with 1h expiry
 	expires := int64(3600)
@@ -151,6 +161,7 @@ func TestTemporaryRuleVisibleInGetRules(t *testing.T) {
 
 func TestGetRules(t *testing.T) {
 	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
 
 	// Create some rules
 	for _, dest := range []string{"a.com", "b.com", "c.com"} {
@@ -178,6 +189,7 @@ func TestGetRules(t *testing.T) {
 
 func TestGetRulesFilter(t *testing.T) {
 	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
 
 	_, _ = CreateRule(db, RuleCreateInput{ContainerPattern: "myapp", DestinationPattern: "a.com", Action: "allow"})
 	_, _ = CreateRule(db, RuleCreateInput{ContainerPattern: "other", DestinationPattern: "b.com", Action: "deny"})
@@ -637,8 +649,8 @@ func TestMigrations(t *testing.T) {
 	// Verify migration versions were recorded
 	var count int
 	_ = db.ReadDB().QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
-	if count != 11 {
-		t.Errorf("expected 11 migration versions, got %d", count)
+	if count != 12 {
+		t.Errorf("expected 12 migration versions, got %d", count)
 	}
 }
 
@@ -1153,5 +1165,397 @@ func TestUpdateLatestLogMitmSkipReasonMatchesResolvedHostname(t *testing.T) {
 	}
 	if !logs[0].MitmSkipReason.Valid || logs[0].MitmSkipReason.String != "mitm_error" {
 		t.Errorf("got mitm_skip_reason %v, want 'mitm_error'", logs[0].MitmSkipReason)
+	}
+}
+
+// --- Session-scoped network rules tests ---
+
+func TestSessionNetworkRulesCreatedOnSessionCreate(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-netrules1",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443", Action: "allow"},
+			{DestinationPattern: "**.openai.com", PortPattern: "443"},
+			{DestinationPattern: "*.evil.com", Action: "deny"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify rules were created
+	rules, total, err := GetRules(db, RuleFilter{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Fatalf("expected 3 session rules, got %d", total)
+	}
+
+	// Verify session_id is set on all rules
+	for _, r := range rules {
+		if !r.SessionID.Valid || r.SessionID.String != "gw-netrules1" {
+			t.Errorf("expected session_id 'gw-netrules1', got %v", r.SessionID)
+		}
+		if r.RuleSource() != "session" {
+			t.Errorf("expected source 'session', got %q", r.RuleSource())
+		}
+	}
+
+	// Verify default values (port_pattern defaults to *, action defaults to allow)
+	ruleByDest := map[string]*Rule{}
+	for i := range rules {
+		ruleByDest[rules[i].DestinationPattern] = &rules[i]
+	}
+
+	if r := ruleByDest["**.openai.com"]; r.Action != "allow" {
+		t.Errorf("expected default action 'allow', got %q", r.Action)
+	}
+	if r := ruleByDest["*.evil.com"]; r.Action != "deny" {
+		t.Errorf("expected deny action, got %q", r.Action)
+	}
+	if r := ruleByDest["*.evil.com"]; r.PortPattern != "*" {
+		t.Errorf("expected default port '*', got %q", r.PortPattern)
+	}
+}
+
+func TestSessionRulesDeletedOnSessionDelete(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-del-rules",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rule exists
+	_, total, _ := GetRules(db, RuleFilter{Limit: 100})
+	if total != 1 {
+		t.Fatalf("expected 1 rule before delete, got %d", total)
+	}
+
+	// Delete session
+	deleted, err := DeleteSession(db, "gw-del-rules")
+	if err != nil || !deleted {
+		t.Fatal("session delete failed")
+	}
+
+	// Rules should be gone
+	_, total, _ = GetRules(db, RuleFilter{Limit: 100})
+	if total != 0 {
+		t.Errorf("expected 0 rules after session delete, got %d", total)
+	}
+}
+
+func TestSessionRulesReplacedOnUpsert(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	// Create session with rule A
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-upsert-rules",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "old-api.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upsert session with rule B
+	_, err = CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-upsert-rules",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v2"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "new-api.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only rule B should exist
+	rules, total, _ := GetRules(db, RuleFilter{Limit: 100})
+	if total != 1 {
+		t.Fatalf("expected 1 rule after upsert, got %d", total)
+	}
+	if rules[0].DestinationPattern != "new-api.com" {
+		t.Errorf("expected new-api.com, got %s", rules[0].DestinationPattern)
+	}
+}
+
+func TestHeartbeatExtendsSessionRuleExpiry(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-hb-rules",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get rule expiry before heartbeat
+	rules, _, _ := GetRules(db, RuleFilter{Limit: 100})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	expiryBefore := rules[0].ExpiresAt.Time
+
+	// Wait for SQLite datetime('now') to advance (1-second resolution)
+	time.Sleep(1100 * time.Millisecond)
+
+	// Heartbeat
+	_, err = HeartbeatSession(db, "gw-hb-rules")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get rule expiry after heartbeat
+	rules, _, _ = GetRules(db, RuleFilter{Limit: 100})
+	expiryAfter := rules[0].ExpiresAt.Time
+
+	if !expiryAfter.After(expiryBefore) {
+		t.Errorf("expected rule expiry to extend after heartbeat, before=%v after=%v", expiryBefore, expiryAfter)
+	}
+}
+
+func TestLayeredRuleResolution(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	// Create a global deny rule
+	_, err := CreateRule(db, RuleCreateInput{
+		ContainerPattern:   "*",
+		DestinationPattern: "blocked.com",
+		Action:             "deny",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session with allow rule for the same destination
+	_, err = CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-layer-test",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "blocked.com", PortPattern: "443", Action: "allow"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Global deny should win over session allow (strict mode)
+	rule := FindMatchingRule(db, "codex", "blocked.com", 443, "")
+	if rule == nil {
+		t.Fatal("expected to find a matching rule")
+	}
+	if rule.Action != "deny" {
+		t.Errorf("expected global deny to win over session allow, got action=%q source=%q", rule.Action, rule.RuleSource())
+	}
+	if rule.RuleSource() != "global" {
+		t.Errorf("expected winning rule source 'global', got %q", rule.RuleSource())
+	}
+}
+
+func TestSessionRuleMatchesContainer(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-container-match",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should match for the session's container
+	rule := FindMatchingRule(db, "codex", "api.openai.com", 443, "")
+	if rule == nil {
+		t.Fatal("expected rule to match for container 'codex'")
+	}
+
+	// Should NOT match for a different container
+	rule = FindMatchingRule(db, "aider", "api.openai.com", 443, "")
+	if rule != nil {
+		t.Errorf("expected no rule for container 'aider', got %+v", rule)
+	}
+}
+
+func TestBuiltinLocalhostRules(t *testing.T) {
+	db := setupTestDB(t)
+	// Don't clear built-in rules - we're testing them
+
+	// 127.0.0.1 should be allowed for any container
+	rule := FindMatchingRule(db, "anycontainer", "127.0.0.1", 8080, "")
+	if rule == nil {
+		t.Fatal("expected built-in rule to match 127.0.0.1")
+	}
+	if rule.Action != "allow" {
+		t.Errorf("expected allow, got %s", rule.Action)
+	}
+	if rule.RuleSource() != "builtin" {
+		t.Errorf("expected source 'builtin', got %q", rule.RuleSource())
+	}
+
+	// ::1 should also be allowed
+	rule = FindMatchingRule(db, "anycontainer", "::1", 3000, "")
+	if rule == nil {
+		t.Fatal("expected built-in rule to match ::1")
+	}
+
+	// localhost via resolved hostname should also match
+	rule = FindMatchingRule(db, "anycontainer", "192.168.1.1", 3000, "localhost")
+	if rule == nil {
+		t.Fatal("expected built-in rule to match resolved hostname 'localhost'")
+	}
+}
+
+func TestContainerAllowAll(t *testing.T) {
+	db := setupTestDB(t)
+	key := testEncryptionKey()
+
+	// No allow_all session: should return false
+	if IsContainerAllowAll(db, "codex") {
+		t.Error("expected IsContainerAllowAll=false before session creation")
+	}
+
+	// Create session with allow_all=true
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-allowall",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		AllowAll:      true,
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsContainerAllowAll(db, "codex") {
+		t.Error("expected IsContainerAllowAll=true after session creation with allow_all")
+	}
+
+	// Different container should not be affected
+	if IsContainerAllowAll(db, "aider") {
+		t.Error("expected IsContainerAllowAll=false for different container")
+	}
+
+	// Delete session, should revert
+	_, _ = DeleteSession(db, "gw-allowall")
+	if IsContainerAllowAll(db, "codex") {
+		t.Error("expected IsContainerAllowAll=false after session deletion")
+	}
+}
+
+func TestSessionRulesDeletedOnExpiry(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-expire-rules",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    1,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for session to expire
+	time.Sleep(2 * time.Second)
+
+	// Delete expired sessions
+	ids, err := DeleteExpiredSessions(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "gw-expire-rules" {
+		t.Errorf("expected expired session gw-expire-rules, got %v", ids)
+	}
+
+	// Session rules should be gone
+	_, total, _ := GetRules(db, RuleFilter{Limit: 100})
+	if total != 0 {
+		t.Errorf("expected 0 rules after session expiry cleanup, got %d", total)
+	}
+}
+
+func TestSessionNetworkRulesWithoutCredentials(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	// Session with only network rules (no credentials)
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-norules-only",
+		ContainerName: "codex",
+		Mappings:      map[string]string{},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := GetSessionRuleCount(db, "gw-norules-only")
+	if count != 1 {
+		t.Errorf("expected 1 session rule, got %d", count)
 	}
 }

--- a/internal/greyproxy/crud_test.go
+++ b/internal/greyproxy/crud_test.go
@@ -1429,6 +1429,95 @@ func TestSessionRuleMatchesContainer(t *testing.T) {
 	}
 }
 
+func TestSessionRuleDoesNotMatchAfterSessionDeleted(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-deleted-session",
+		ContainerName: "codex",
+		Mappings:      map[string]string{"p": "v"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.openai.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rule matches while session is active
+	rule := FindMatchingRule(db, "codex", "api.openai.com", 443, "")
+	if rule == nil {
+		t.Fatal("expected rule to match while session is active")
+	}
+
+	// Delete the session
+	_, err = DeleteSession(db, "gw-deleted-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rule must NOT match once the session is gone
+	rule = FindMatchingRule(db, "codex", "api.openai.com", 443, "")
+	if rule != nil {
+		t.Errorf("expected no rule after session deletion, got rule %d (session_id=%v)", rule.ID, rule.SessionID)
+	}
+}
+
+// TestNewerSessionSupersedesOlderSessionRules verifies that when a second session is
+// created for the same container, the first session's rules no longer apply -- even
+// while session 1 is still active. This is the core "session isolation" invariant:
+// the most recently created active session defines the effective rule set.
+func TestNewerSessionSupersedesOlderSessionRules(t *testing.T) {
+	db := setupTestDB(t)
+	clearBuiltinRules(t, db)
+	key := testEncryptionKey()
+
+	// Session 1: created with network rules (e.g. greywall --profile llm-coding)
+	_, err := CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-session-1",
+		ContainerName: "claude",
+		Mappings:      map[string]string{"p1": "v1"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules: []SessionNetworkRule{
+			{DestinationPattern: "api.anthropic.com", PortPattern: "443"},
+		},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Session 1 is active: its rule must match
+	rule := FindMatchingRule(db, "claude", "api.anthropic.com", 443, "")
+	if rule == nil {
+		t.Fatal("expected rule to match for session 1")
+	}
+
+	// Session 2: same container, no network rules (e.g. greywall --no-network-rules)
+	// Session 1 is still alive (not deleted, not expired).
+	_, err = CreateOrUpdateSession(db, SessionCreateInput{
+		SessionID:     "gw-session-2",
+		ContainerName: "claude",
+		Mappings:      map[string]string{"p2": "v2"},
+		Labels:        map[string]string{},
+		TTLSeconds:    300,
+		NetworkRules:  nil,
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Session 2 is the current session: session 1's rules must NOT match anymore
+	rule = FindMatchingRule(db, "claude", "api.anthropic.com", 443, "")
+	if rule != nil {
+		t.Errorf("session 1 rule must not apply when session 2 is active, got rule %d (session_id=%v)", rule.ID, rule.SessionID)
+	}
+}
+
 func TestBuiltinLocalhostRules(t *testing.T) {
 	db := setupTestDB(t)
 	// Don't clear built-in rules - we're testing them

--- a/internal/greyproxy/migrations.go
+++ b/internal/greyproxy/migrations.go
@@ -178,7 +178,7 @@ var migrations = []string{
 	);`,
 
 	// Migration 11: Endpoint rules for dynamic URL pattern -> decoder mapping,
-	// and client_name on conversations for detected client identity
+	// and client_name on conversations for detected client identity.
 	`CREATE TABLE IF NOT EXISTS endpoint_rules (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		host_pattern TEXT NOT NULL,
@@ -194,6 +194,25 @@ var migrations = []string{
 	    ON endpoint_rules(host_pattern, path_pattern, method, user_defined);
 
 	ALTER TABLE conversations ADD COLUMN client_name TEXT;`,
+
+	// Migration 12: Session-scoped network rules and per-container allow-all.
+	//
+	// - session_id on rules links a rule to a session lifetime (auto-deleted on session end/expire).
+	//   Source layer is derived: session_id IS NOT NULL = session rule, created_by = 'builtin' = built-in,
+	//   everything else = global. rule_type stays 'permanent'/'temporary' (CHECK constraint from migration 1).
+	// - allow_all on sessions enables per-container learning mode (skip ACL for that container).
+	// - Built-in localhost rules seed 127.0.0.1, ::1, and localhost as lowest-priority allows.
+	`ALTER TABLE rules ADD COLUMN session_id TEXT DEFAULT NULL;
+	CREATE INDEX IF NOT EXISTS idx_rules_session_id ON rules(session_id);
+
+	ALTER TABLE sessions ADD COLUMN allow_all INTEGER NOT NULL DEFAULT 0;
+
+	INSERT OR IGNORE INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+	VALUES ('*', '127.0.0.1', '*', 'permanent', 'allow', 'builtin');
+	INSERT OR IGNORE INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+	VALUES ('*', '::1', '*', 'permanent', 'allow', 'builtin');
+	INSERT OR IGNORE INTO rules (container_pattern, destination_pattern, port_pattern, rule_type, action, created_by)
+	VALUES ('*', 'localhost', '*', 'permanent', 'allow', 'builtin');`,
 }
 
 func runMigrations(db *sql.DB) error {

--- a/internal/greyproxy/models.go
+++ b/internal/greyproxy/models.go
@@ -19,6 +19,34 @@ type Rule struct {
 	LastUsedAt         sql.NullTime   `json:"last_used_at"`
 	CreatedBy          string         `json:"created_by"`
 	Notes              sql.NullString `json:"notes"`
+	SessionID          sql.NullString `json:"session_id"`
+}
+
+// RuleSource returns the source layer for rule resolution priority.
+// Global (human-created) > Session (profile-scoped) > Builtin (localhost defaults).
+func (r *Rule) RuleSource() string {
+	if r.CreatedBy == "builtin" {
+		return "builtin"
+	}
+	if r.SessionID.Valid && r.SessionID.String != "" {
+		return "session"
+	}
+	return "global"
+}
+
+// RuleSourcePriority returns the numeric priority for the source layer.
+// Higher = stronger.
+func (r *Rule) RuleSourcePriority() int {
+	switch r.RuleSource() {
+	case "global":
+		return 3
+	case "session":
+		return 2
+	case "builtin":
+		return 1
+	default:
+		return 0
+	}
 }
 
 type RuleJSON struct {
@@ -34,6 +62,8 @@ type RuleJSON struct {
 	CreatedBy          string  `json:"created_by"`
 	Notes              *string `json:"notes"`
 	IsActive           bool    `json:"is_active"`
+	SessionID          *string `json:"session_id,omitempty"`
+	Source             string  `json:"source"` // "global", "session", or "builtin"
 }
 
 func (r *Rule) ToJSON() RuleJSON {
@@ -47,6 +77,7 @@ func (r *Rule) ToJSON() RuleJSON {
 		CreatedAt:          r.CreatedAt.UTC().Format(time.RFC3339),
 		CreatedBy:          r.CreatedBy,
 		IsActive:           !r.ExpiresAt.Valid || r.ExpiresAt.Time.After(time.Now()),
+		Source:             r.RuleSource(),
 	}
 	if r.ExpiresAt.Valid {
 		s := r.ExpiresAt.Time.UTC().Format(time.RFC3339)
@@ -58,6 +89,9 @@ func (r *Rule) ToJSON() RuleJSON {
 	}
 	if r.Notes.Valid {
 		j.Notes = &r.Notes.String
+	}
+	if r.SessionID.Valid {
+		j.SessionID = &r.SessionID.String
 	}
 	return j
 }
@@ -359,6 +393,15 @@ type TimelinePoint struct {
 	Blocked   int    `json:"blocked"`
 }
 
+// SessionNetworkRule is a network rule sent by greywall as part of session creation.
+// These rules are scoped to the session lifetime and auto-deleted on session end.
+type SessionNetworkRule struct {
+	DestinationPattern string `json:"destination_pattern"`
+	PortPattern        string `json:"port_pattern,omitempty"` // default "*"
+	Action             string `json:"action,omitempty"`       // default "allow"
+	Notes              string `json:"notes,omitempty"`
+}
+
 // Session represents a credential substitution session registered by greywall.
 type Session struct {
 	SessionID         string    `json:"session_id"`
@@ -371,6 +414,7 @@ type Session struct {
 	ExpiresAt         time.Time `json:"expires_at"`
 	LastHeartbeat     time.Time `json:"last_heartbeat"`
 	SubstitutionCount int64     `json:"substitution_count"`
+	AllowAll          bool      `json:"allow_all"`
 }
 
 type SessionJSON struct {
@@ -384,6 +428,7 @@ type SessionJSON struct {
 	ExpiresAt         string            `json:"expires_at"`
 	LastHeartbeat     string            `json:"last_heartbeat"`
 	SubstitutionCount int64             `json:"substitution_count"`
+	AllowAll          bool              `json:"allow_all"`
 }
 
 func (s *Session) ToJSON(labels map[string]string) SessionJSON {
@@ -406,6 +451,7 @@ func (s *Session) ToJSON(labels map[string]string) SessionJSON {
 		ExpiresAt:         s.ExpiresAt.UTC().Format(time.RFC3339),
 		LastHeartbeat:     s.LastHeartbeat.UTC().Format(time.RFC3339),
 		SubstitutionCount: s.SubstitutionCount,
+		AllowAll:          s.AllowAll,
 	}
 }
 

--- a/internal/greyproxy/plugins/bypass.go
+++ b/internal/greyproxy/plugins/bypass.go
@@ -140,6 +140,16 @@ func (b *Bypass) Contains(ctx context.Context, network, addr string, opts ...byp
 		containerName, containerID = ResolveIdentity(clientID, srcIP)
 	}
 
+	// Per-container allow-all: if this container has an active session with allow_all=true,
+	// bypass ACL evaluation for it (used by greywall --learning mode).
+	if containerName != "" && greyproxy.IsContainerAllowAll(b.db, containerName) {
+		resolvedHostname := b.resolveHostname(host)
+		elapsed := time.Since(start).Milliseconds()
+		go b.logRequest(containerName, containerID, host, port, resolvedHostname, methodFromService(o.Service), "allowed", nil, &elapsed)
+		b.log.Debugf("SESSION-ALLOW-ALL %s -> %s:%d (%s)", containerName, host, port, network)
+		return false // allow
+	}
+
 	// Resolve hostname
 	resolvedHostname := b.resolveHostname(host)
 

--- a/internal/greyproxy/ui/templates/partials/rules_list.html
+++ b/internal/greyproxy/ui/templates/partials/rules_list.html
@@ -35,6 +35,11 @@
                             <span class="text-xs text-accent ml-1">Temporary</span>
                         {{end}}
                     {{end}}
+                    {{if .SessionID.Valid}}
+                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/10 text-accent ml-1">session</span>
+                    {{else if eq .CreatedBy "builtin"}}
+                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground ml-1">builtin</span>
+                    {{end}}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary cursor-pointer hover:underline hover:bg-primary/20"


### PR DESCRIPTION
## Summary
- Greywall can now attach network rules to a session at creation time; rules are scoped to the session lifetime and auto-deleted when the session ends, expires, or is superseded.
- Layered rule resolution: `global > session > builtin > default-deny`. Within a layer, specificity wins and deny beats allow at equal specificity.
- Per-container `allow_all` for greywall learning mode (skips ACL for that container).
- Built-in localhost rules (`127.0.0.1`, `::1`, `localhost`) seeded at the lowest priority so loopback always works.
- Session rules are JOINed with the `sessions` table at match time, and a session rule only matches when its session is the **most recently created active session** for the connecting container. This prevents an older session's rules from leaking into a newer session started for the same container (e.g. greywall run with \`--no-network-rules\`).

## Test plan
- [x] Unit tests for session rule create/upsert/delete/expire lifecycle
- [x] Unit tests for layered resolution (global > session > builtin)
- [x] Unit test: session rule does not match after its session is deleted
- [x] Unit test: newer session for the same container supersedes older session rules
- [x] Unit tests for built-in localhost rules and per-container allow-all
