### PR TITLE
fix: preserve systemd-resolved stub in DNS auto-detection

### DIFF
--- a/cmd/greyproxy/sysdns.go
+++ b/cmd/greyproxy/sysdns.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+// stubResolvConfPath is the file systemd-resolved writes with its stub
+// listener (127.0.0.53) as the only nameserver. We read it when
+// /etc/resolv.conf is missing so queries still go through resolved and
+// benefit from its DoT/DNSSEC/split-DNS handling.
+//
+// We deliberately never read /run/systemd/resolve/resolv.conf: that file
+// contains the raw upstream nameservers and using it bypasses
+// systemd-resolved entirely, breaking DoT-only setups (see issue #47).
+const stubResolvConfPath = "/run/systemd/resolve/stub-resolv.conf"
+
 // systemDNSServers returns the host's configured DNS resolver addresses in
 // "host:53" form. Falls back to ["8.8.8.8:53"] when detection fails so the
 // DNS proxy always has a working upstream.
@@ -24,42 +34,22 @@ func systemDNSServers() []string {
 	return servers
 }
 
-// linuxMacDNSServers reads DNS servers from /etc/resolv.conf.
+// linuxMacDNSServers reads DNS servers from /etc/resolv.conf verbatim.
 //
-// systemd-resolved typically sets /etc/resolv.conf to contain only
-// "nameserver 127.0.0.53" (its stub listener). That address is reachable on
-// the host, but NOT inside containers (127.x.x.x is the container's own
-// loopback, not the host's). In that case we fall back to
-// /run/systemd/resolve/resolv.conf which systemd-resolved writes with the
-// real upstream nameservers.
+// On systemd-resolved hosts /etc/resolv.conf usually contains only
+// "nameserver 127.0.0.53" (the stub listener). We keep that address as-is
+// so queries are handled by resolved and go through whatever DoT/DNSSEC/
+// split-DNS config the user has set up. Bypassing the stub would drop all
+// of that (see issue #47).
+//
+// If /etc/resolv.conf is missing (rare, but possible on minimal images) we
+// fall back to /run/systemd/resolve/stub-resolv.conf, which also points at
+// the stub listener and keeps queries flowing through resolved.
 func linuxMacDNSServers() []string {
-	servers := resolvConfServers("/etc/resolv.conf")
-
-	// If every server is the systemd stub (127.0.0.53) try to get the real
-	// upstreams. Other loopback resolvers (dnsmasq on 127.0.0.1, etc.) are
-	// left alone because they are intentionally local.
-	if allSystemdStub(servers) {
-		if real := resolvConfServers("/run/systemd/resolve/resolv.conf"); len(real) > 0 {
-			return real
-		}
+	if servers := resolvConfServers("/etc/resolv.conf"); len(servers) > 0 {
+		return servers
 	}
-
-	return servers
-}
-
-// allSystemdStub reports whether every server address is the systemd-resolved
-// stub listener (127.0.0.53). A single non-stub address makes this false.
-func allSystemdStub(servers []string) bool {
-	if len(servers) == 0 {
-		return false
-	}
-	for _, s := range servers {
-		host, _, _ := net.SplitHostPort(s)
-		if host != "127.0.0.53" {
-			return false
-		}
-	}
-	return true
+	return resolvConfServers(stubResolvConfPath)
 }
 
 // resolvConfServers parses nameserver lines from a resolv.conf-style file.

--- a/cmd/greyproxy/sysdns_test.go
+++ b/cmd/greyproxy/sysdns_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeResolvConf(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resolv.conf")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp resolv.conf: %v", err)
+	}
+	return path
+}
+
+func TestResolvConfServers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name: "systemd stub is returned verbatim, not bypassed",
+			// Regression for issue #47: 0.4.1 replaced 127.0.0.53 with the
+			// raw upstream from /run/systemd/resolve/resolv.conf, breaking
+			// hosts whose resolved is configured with DoT-only upstreams.
+			content: "# comment\nnameserver 127.0.0.53\noptions edns0 trust-ad\n",
+			want:    []string{"127.0.0.53:53"},
+		},
+		{
+			name:    "multiple ipv4 nameservers preserved in order",
+			content: "nameserver 1.1.1.1\nnameserver 8.8.8.8\n",
+			want:    []string{"1.1.1.1:53", "8.8.8.8:53"},
+		},
+		{
+			name:    "ipv6 nameserver is bracketed",
+			content: "nameserver 2001:4860:4860::8888\n",
+			want:    []string{"[2001:4860:4860::8888]:53"},
+		},
+		{
+			name:    "malformed and blank lines are skipped",
+			content: "\nnameserver\nnameserver notanip\nnameserver 9.9.9.9\n",
+			want:    []string{"9.9.9.9:53"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeResolvConf(t, tc.content)
+			got := resolvConfServers(path)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("resolvConfServers() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvConfServersMissingFile(t *testing.T) {
+	got := resolvConfServers(filepath.Join(t.TempDir(), "does-not-exist"))
+	if got != nil {
+		t.Fatalf("expected nil for missing file, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Stop bypassing systemd-resolved in `linuxMacDNSServers()`: read `/etc/resolv.conf` verbatim instead of swapping the stub out for the raw upstreams in `/run/systemd/resolve/resolv.conf`.
- Fall back to `/run/systemd/resolve/stub-resolv.conf` only when `/etc/resolv.conf` is absent (minimal images). The raw upstream file is never read.
- Add `sysdns_test.go` covering the 127.0.0.53 regression, multi-nameserver order, IPv6 bracketing, malformed lines, and missing files.

## Why
0.4.1 (#43) replaced 127.0.0.53 with the raw Mullvad upstream from `/run/systemd/resolve/resolv.conf`, so greyproxy tried plain UDP/53 to an upstream that systemd-resolved had been reaching over DoT. On hosts configured with `DNSOverTLS=opportunistic` (matclab's setup in #47) the direct UDP path is unreachable and every lookup times out. Letting queries flow through 127.0.0.53 keeps DoT, DNSSEC, and split-DNS intact.

The container concern the original code cited (127.x.x.x being container-local) doesn't apply: greyproxy runs on the host, and the sandboxed client connects to it via the host's loopback, so 127.0.0.53 is reachable.

Fixes #47

## Test plan
- [x] `go test ./cmd/greyproxy/ -run TestResolvConf -v`
- [x] `go build ./...`
- [x] `go vet ./cmd/greyproxy/`