### PR TITLE
perf: buffer HTTP response writes to reduce TLS syscalls

### DIFF
--- a/internal/gostx/handler/http/handler.go
+++ b/internal/gostx/handler/http/handler.go
@@ -668,7 +668,11 @@ func (h *httpHandler) proxyRoundTrip(ctx context.Context, rw io.ReadWriteCloser,
 		resp.Body = respBody
 	}
 
-	err = resp.Write(rw)
+	bw := bufio.NewWriterSize(rw, 8192)
+	err = resp.Write(bw)
+	if fErr := bw.Flush(); err == nil {
+		err = fErr
+	}
 
 	if respBody != nil {
 		ro.HTTP.Response.Body = respBody.Content()

--- a/internal/gostx/internal/util/sniffing/sniffer.go
+++ b/internal/gostx/internal/util/sniffing/sniffer.go
@@ -635,7 +635,11 @@ func (h *Sniffer) httpRoundTrip(ctx context.Context, rw, cc io.ReadWriteCloser, 
 		resp.Body = respBody
 	}
 
-	err = resp.Write(rw)
+	bw := bufio.NewWriterSize(rw, 8192)
+	err = resp.Write(bw)
+	if fErr := bw.Flush(); err == nil {
+		err = fErr
+	}
 
 	if respBody != nil {
 		ro.HTTP.Response.Body = respBody.Content()


### PR DESCRIPTION
resp.Write() emits many small writes (status line, headers, body chunks). On a TLS connection each write becomes a separate encryption and write() syscall. Wrapping with an 8 KB bufio.Writer coalesces these into fewer, larger TLS records.

Applied to both the HTTP handler and the MITM sniffer write paths.