### PR TITLE
fix: index http_transactions.container_name to speed up pending page

### DIFF
--- a/internal/greyproxy/crud_test.go
+++ b/internal/greyproxy/crud_test.go
@@ -649,8 +649,8 @@ func TestMigrations(t *testing.T) {
 	// Verify migration versions were recorded
 	var count int
 	_ = db.ReadDB().QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
-	if count != 14 {
-		t.Errorf("expected 14 migration versions, got %d", count)
+	if count != 15 {
+		t.Errorf("expected 15 migration versions, got %d", count)
 	}
 }
 

--- a/internal/greyproxy/migrations.go
+++ b/internal/greyproxy/migrations.go
@@ -239,6 +239,12 @@ var migrations = []string{
 	// returned by the middleware in its hello response. NULL for middlewares
 	// that did not declare a name; the UI falls back to middleware_url.
 	`ALTER TABLE middleware_events ADD COLUMN middleware_name TEXT;`,
+
+	// Migration 15: Index http_transactions.container_name to speed up the
+	// container filter on the pending page. Without it, the DISTINCT
+	// container_name lookup full-scans http_transactions (BLOB-heavy), which
+	// made GET /pending take ~30s on large databases.
+	`CREATE INDEX IF NOT EXISTS idx_http_transactions_container ON http_transactions(container_name);`,
 }
 
 func runMigrations(db *sql.DB) error {


### PR DESCRIPTION
Disclaimer: PR coded by claude code, I don’t understand code and implications. 
but it works on my setup.

thank you !

warning, bellow this line it’s slop (measured time are confirmed).
-----


The pending page's container filter runs SELECT DISTINCT container_name across pending_requests, request_logs, and http_transactions. The first two are indexed; http_transactions was not, forcing a full scan of a BLOB-heavy table (~170k rows, the bulk of a  20 GB database). On a DB this size, GET /pending took ~10s. Adding the index drops it to sub-second (measured 11.8s -> 0.74s cold, 0.016s warm).